### PR TITLE
#34234 Metalama.Compiler is missing debugging symbols in the symbols NuGet package

### DIFF
--- a/src/Metalama/Metalama.Compiler.Sdk/Metalama.Compiler.Sdk.csproj
+++ b/src/Metalama/Metalama.Compiler.Sdk/Metalama.Compiler.Sdk.csproj
@@ -8,6 +8,8 @@
     <PackageId>Metalama.Compiler.Sdk</PackageId>
     <PackageDescription>Defines the ISourceTransformer interface as well as other APIs that allow you to write source transformers for Metalama.Compiler.</PackageDescription>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <!-- Enable portable PDB so it can be included in the symbols NuGet package (.snupkg). -->
+    <DebugType>Portable</DebugType>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
…cluded in .snupkg package.