### PR TITLE
#34268 Fix build of Roslyn tests by excluding .Net 8 TFM

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Microsoft.CodeAnalysis.UnitTests.csproj
+++ b/src/Compilers/Core/CodeAnalysisTest/Microsoft.CodeAnalysis.UnitTests.csproj
@@ -5,7 +5,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.CodeAnalysis.UnitTests</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>net8.0;net7.0;net472</TargetFrameworks>
+    <!-- <Metalama> Removed net8.0: the combination of this pre-.Net 8.0 compiler and final .Net 8.0 is problematic with regards to ref readonly. -->
+    <TargetFrameworks>net7.0;net472</TargetFrameworks>
+    <!-- </Metalama> -->
   </PropertyGroup>
   <ItemGroup Label="Linked Files">
     <Compile Include="..\..\Shared\GlobalAssemblyCacheHelpers\FusionAssemblyIdentity.cs">


### PR DESCRIPTION
Note that this change should not be made to 2023.4 and later. I will try to do downstream merge manually to achieve that.