### PR TITLE
#35016 Add back .Net Framework System.Composition assemblies to the package

### DIFF
--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/MetalamaCompilerArtifacts.targets
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/MetalamaCompilerArtifacts.targets
@@ -72,6 +72,11 @@
       <DesktopMetalamaCompilerBinArtifact Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.Features\$(Configuration)\netstandard2.0\Microsoft.CodeAnalysis.Features.dll" />
       <DesktopMetalamaCompilerBinArtifact Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CSharp.Features\$(Configuration)\netstandard2.0\Microsoft.CodeAnalysis.CSharp.Features.dll" />
       <DesktopMetalamaCompilerBinArtifact Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.Scripting\$(Configuration)\netstandard2.0\Microsoft.CodeAnalysis.Scripting.dll"/>
+      <DesktopMetalamaCompilerBinArtifact Include="$(PkgSystem_Composition_AttributedModel)\lib\net462\System.Composition.AttributedModel.dll"/>
+      <DesktopMetalamaCompilerBinArtifact Include="$(PkgSystem_Composition_Convention)\lib\net462\System.Composition.Convention.dll"/>
+      <DesktopMetalamaCompilerBinArtifact Include="$(PkgSystem_Composition_Hosting)\lib\net462\System.Composition.Hosting.dll"/>
+      <DesktopMetalamaCompilerBinArtifact Include="$(PkgSystem_Composition_Runtime)\lib\net462\System.Composition.Runtime.dll"/>
+      <DesktopMetalamaCompilerBinArtifact Include="$(PkgSystem_Composition_TypedParts)\lib\net462\System.Composition.TypedParts.dll"/>
       <DesktopMetalamaCompilerBinArtifact Include="$(PkgMicrosoft_Bcl_AsyncInterfaces)\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll"/>
       <DesktopMetalamaCompilerBinArtifact Include="$(PkgSystem_ValueTuple)\lib\net47\System.ValueTuple.dll"/>
     </ItemGroup>


### PR DESCRIPTION
In [this change](https://github.com/postsharp/Metalama.Compiler/pull/38/commits/8c3c5bb5b18f8a278da5f0cef2bdf54121b259e7#diff-50e9dfd2775eef5a394d43995d5528fa0929b51b319b4e2c05c44bf59314a071) I noticed that the package doesn't contain any `netstandard1.0` assemblies, so the old code did nothing and should have been removed.

But then I also removed the .Net Framework version of the code, which did work and was necessary.