### PR TITLE
Force using .Net 9 RC 1 to work around RC 2 bug

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,8 +1,8 @@
 {
   "sdk": {
-    "version": "9.0.100-preview.5.24307.3",
+    "version": "9.0.100-rc.1.24452.12",
     "allowPrerelease": false,
-    "rollForward": "minor"
+    "rollForward": "disable"
   },
   "tools": {
     "dotnet": "9.0.100-preview.5.24307.3",


### PR DESCRIPTION
See https://github.com/dotnet/msbuild/issues/10579.