### PR TITLE
Make transformed source files read-only (#745)

### DIFF
--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -1572,6 +1572,14 @@ namespace Microsoft.CodeAnalysis
                         if (shouldSaveTransformedCode && Directory.Exists(transformedOutputPath))
                         {
                             logger.Trace?.Log($"Deleting '{transformedOutputPath}'");
+
+                            // Remove read-only attributes before deleting, because Directory.Delete
+                            // fails on read-only files.
+                            foreach (var file in Directory.GetFiles(transformedOutputPath, "*", SearchOption.AllDirectories))
+                            {
+                                File.SetAttributes(file, FileAttributes.Normal);
+                            }
+
                             Directory.Delete(transformedOutputPath, true);
                         }
 
@@ -1627,6 +1635,9 @@ namespace Microsoft.CodeAnalysis
                                     touchedFilesLogger?.AddWritten(fullPath);
                                     pathMap.Add(new(tree.FilePath, fullPath));
                                 }
+
+                                // Set the file as read-only so we have no temptation to edit it.
+                                File.SetAttributes(fullPath, FileAttributes.ReadOnly);
                             }
                             else
                             {
@@ -1654,6 +1665,9 @@ namespace Microsoft.CodeAnalysis
 
                                 new JsonSerializer().Serialize(writer, new TransformedFilesMap(pathMap));
                             }
+
+                            // Set the file as read-only so we have no temptation to edit it.
+                            File.SetAttributes(path, FileAttributes.ReadOnly);
                         }
 
                         mappedAnalyzerOptions = CompilerAnalyzerConfigOptionsProvider.MapSyntaxTrees(mappedAnalyzerOptions, treeMap);

--- a/src/Metalama/Metalama.Compiler.UnitTests/SourceTransformersTests.cs
+++ b/src/Metalama/Metalama.Compiler.UnitTests/SourceTransformersTests.cs
@@ -232,6 +232,65 @@ build_property.MSBuildProjectFullPath = {projectDirectory.Path}\MyProject.csproj
         Directory.Delete(projectDirectory.Path, true);
     }
 
+    /// <summary>
+    ///     Tests that transformed source files are marked as read-only to discourage editing.
+    /// </summary>
+    [Fact]
+    public void TransformedSourcesAreReadOnly()
+    {
+        var projectDirectory = Temp.CreateDirectory();
+        var src1 = projectDirectory.CreateFile("C.cs").WriteAllText("class C { }");
+        var transformedDir = projectDirectory.CreateDirectory("transformed");
+        var analyzerConfig = projectDirectory.CreateFile(".editorconfig").WriteAllText($@"
+is_global = true
+build_property.MetalamaCompilerTransformedFilesOutputPath = {transformedDir.Path}
+build_property.MSBuildProjectFullPath = {projectDirectory.Path}\MyProject.csproj"
+        );
+
+        var args = new[]
+        {
+            "/t:library", $"/analyzerconfig:{analyzerConfig.Path}", src1.Path, "/out:lib.dll"
+        };
+
+        var csc = CreateCSharpCompiler(null, projectDirectory.Path, args,
+            transformers: [new DoSomethingTransformer()]);
+
+        var outWriter = new StringWriter(CultureInfo.InvariantCulture);
+        var exitCode = csc.Run(outWriter);
+
+        Assert.Equal(0, exitCode);
+
+        // Verify transformed source file is read-only.
+        var transformedFile = Path.Combine(transformedDir.Path, "C.cs");
+        Assert.True(File.Exists(transformedFile));
+        var attributes = File.GetAttributes(transformedFile);
+        Assert.True((attributes & FileAttributes.ReadOnly) != 0, "Transformed source file should be read-only.");
+
+        // Verify generated file is also read-only.
+        var generatedFile = Path.Combine(transformedDir.Path, "Unnamed.cs");
+        Assert.True(File.Exists(generatedFile));
+        var generatedAttributes = File.GetAttributes(generatedFile);
+        Assert.True((generatedAttributes & FileAttributes.ReadOnly) != 0, "Generated source file should be read-only.");
+
+        // Verify that a subsequent build successfully replaces the read-only files.
+        var csc2 = CreateCSharpCompiler(null, projectDirectory.Path, args,
+            transformers: [new DoSomethingTransformer()]);
+
+        var outWriter2 = new StringWriter(CultureInfo.InvariantCulture);
+        var exitCode2 = csc2.Run(outWriter2);
+
+        Assert.Equal(0, exitCode2);
+
+        // Clean up: remove read-only attributes before deleting.
+        foreach (var file in Directory.GetFiles(transformedDir.Path, "*", SearchOption.AllDirectories))
+        {
+            File.SetAttributes(file, FileAttributes.Normal);
+        }
+
+        CleanupAllGeneratedFiles(src1.Path);
+        Directory.Delete(projectDirectory.Path, true);
+    }
+
     [Fact]
     public void AddManagedResourcesInNormalAssemblies()
     {

--- a/src/Metalama/Metalama.Compiler.UnitTests/SourceTransformersTests.cs
+++ b/src/Metalama/Metalama.Compiler.UnitTests/SourceTransformersTests.cs
@@ -226,7 +226,12 @@ build_property.MSBuildProjectFullPath = {projectDirectory.Path}\MyProject.csproj
         var generatedFile = Path.Combine(transformedDir.Path, "Unnamed.cs");
         Assert.Equal("class G {}", File.ReadAllText(generatedFile));
 
-        // Clean up temp files
+        // Clean up: remove read-only attributes before deleting.
+        foreach (var file in Directory.GetFiles(transformedDir.Path, "*", SearchOption.AllDirectories))
+        {
+            File.SetAttributes(file, FileAttributes.Normal);
+        }
+
         CleanupAllGeneratedFiles(src1.Path);
         CleanupAllGeneratedFiles(src2.Path);
         Directory.Delete(projectDirectory.Path, true);


### PR DESCRIPTION
## Summary

- Adds a regression test verifying that transformed source files written to `obj/<Config>/<TFM>/metalama/` are marked as read-only on the file system, to discourage editing (edits are lost on rebuild).
- Verifies that subsequent builds can replace the read-only files.

Fixes https://github.com/metalama/Metalama/issues/745

## Checklist

- [x] Reproduce bug (failing test)
- [ ] Implement fix (set `FileAttributes.ReadOnly` on transformed files)
- [ ] Handle read-only files during directory cleanup
- [ ] Build passes
- [ ] All tests pass
- [ ] Finalize

— Claude for @gfraiteur