### PR TITLE
Ship ARM64 binaries in Metalama.Compiler package (#104)

### DIFF
--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/AnyCpu/Metalama.Compiler.Package.csproj
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/AnyCpu/Metalama.Compiler.Package.csproj
@@ -36,6 +36,7 @@
     <_DependsOn Condition="'$(TargetFramework)' != 'net472'">InitializeCoreClrCompilerArtifacts</_DependsOn>
     <!-- <Metalama> -->
     <_DependsOn>$(_DependsOn);InitializeMetalamaCompilerBinArtifacts</_DependsOn>
+    <_DependsOn Condition="'$(TargetFramework)' == 'net472'">$(_DependsOn);InitializeArm64DesktopCompilerArtifacts</_DependsOn>
     <!-- </Metalama> -->
   </PropertyGroup>
 
@@ -47,6 +48,11 @@
     </Metalama> -->
     <ProjectReference Include="..\..\..\Compilers\Core\MSBuildTask\MSBuild\Microsoft.Build.Tasks.CodeAnalysis.csproj" PrivateAssets="All"/>
     <ProjectReference Include="..\..\..\Compilers\Server\VBCSCompiler\AnyCpu\VBCSCompiler.csproj" PrivateAssets="All"/>
+
+    <!-- <Metalama> ARM64 compiler binaries (#104) -->
+    <ProjectReference Include="..\..\..\Compilers\CSharp\csc\arm64\csc-arm64.csproj" PrivateAssets="All" Condition="'$(TargetFramework)' == 'net472'" />
+    <ProjectReference Include="..\..\..\Compilers\Server\VBCSCompiler\arm64\VBCSCompiler-arm64.csproj" PrivateAssets="All" Condition="'$(TargetFramework)' == 'net472'" />
+    <!-- </Metalama> -->
 
     <ProjectReference Update="@(ProjectReference)"
                       Targets="Publish"
@@ -87,6 +93,12 @@
       <_File Include="@(CoreClrMetalamaCompilerBinArtifact)" TargetDir="tasks/$(TargetFramework)/bincore" Condition="'$(TargetFramework)' != 'net472'" />
       <_File Include="$(NetSdkAnalyzersPath)\*.dll" TargetDir="sdkAnalyzers" Condition="'$(TargetFramework)' == 'net472'" />
 
+      <!-- ARM64 desktop binaries (#104) -->
+      <_File Include="@(Arm64DesktopCompilerArtifact)" TargetDir="tasks/net472-arm64" Condition="'$(TargetFramework)' == 'net472'" />
+      <_File Include="@(Arm64DesktopCompilerResourceArtifact)" TargetDir="tasks/net472-arm64" Condition="'$(TargetFramework)' == 'net472'" />
+      <_File Include="@(CommonMetalamaCompilerBinArtifact)" TargetDir="tasks/net472-arm64" Condition="'$(TargetFramework)' == 'net472'" />
+      <_File Include="@(DesktopMetalamaCompilerBinArtifact)" TargetDir="tasks/net472-arm64" Condition="'$(TargetFramework)' == 'net472'" />
+
       <TfmSpecificPackageFile Include="@(_File)" PackagePath="%(_File.TargetDir)/%(_File.RecursiveDir)%(_File.FileName)%(_File.Extension)" />
     </ItemGroup>
     <!-- </Metalama> -->
@@ -97,6 +109,7 @@
   
   <!-- <Metalama> -->
   <Import Project="..\MetalamaCompilerArtifacts.targets" />
+  <Import Project="..\Arm64DesktopCompilerArtifacts.targets" Condition="'$(TargetFramework)' == 'net472'" />
   <Target Name="UpdateXlf"></Target>
   <!-- </Metalama> -->
 </Project>

--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/AnyCpu/build/Metalama.Compiler.props
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/AnyCpu/build/Metalama.Compiler.props
@@ -23,7 +23,7 @@
      <RoslynCompilerType>Metalama</RoslynCompilerType>
     <!-- </Metalama> -->
     <!-- <Metalama> Use ARM64-native compiler on ARM64 Windows to avoid x64 emulation (#104) -->
-    <_RoslynTargetDirectoryName Condition="'$(MSBuildRuntimeType)' != 'Core' AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">net472-arm64</_RoslynTargetDirectoryName>
+    <_RoslynTargetDirectoryName Condition="'$(MSBuildRuntimeType)' != 'Core' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64'">net472-arm64</_RoslynTargetDirectoryName>
     <!-- </Metalama> -->
     <_RoslynTargetDirectoryName Condition="'$(MSBuildRuntimeType)' != 'Core' AND '$(_RoslynTargetDirectoryName)' == ''">net472</_RoslynTargetDirectoryName>
     <_RoslynTasksDirectory>$(MSBuildThisFileDirectory)..\tasks\$(_RoslynTargetDirectoryName)\</_RoslynTasksDirectory>

--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/AnyCpu/build/Metalama.Compiler.props
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/AnyCpu/build/Metalama.Compiler.props
@@ -22,7 +22,10 @@
     <_RoslynTargetDirectoryName Condition="'$(MSBuildRuntimeType)' == 'Core' AND $([MSBuild]::VersionGreaterThanOrEquals('$(_MetalamaBuildRuntimeVersion)', '10.0'))">net10.0</_RoslynTargetDirectoryName>
      <RoslynCompilerType>Metalama</RoslynCompilerType>
     <!-- </Metalama> -->
-    <_RoslynTargetDirectoryName Condition="'$(MSBuildRuntimeType)' != 'Core'">net472</_RoslynTargetDirectoryName>
+    <!-- <Metalama> Use ARM64-native compiler on ARM64 Windows to avoid x64 emulation (#104) -->
+    <_RoslynTargetDirectoryName Condition="'$(MSBuildRuntimeType)' != 'Core' AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">net472-arm64</_RoslynTargetDirectoryName>
+    <!-- </Metalama> -->
+    <_RoslynTargetDirectoryName Condition="'$(MSBuildRuntimeType)' != 'Core' AND '$(_RoslynTargetDirectoryName)' == ''">net472</_RoslynTargetDirectoryName>
     <_RoslynTasksDirectory>$(MSBuildThisFileDirectory)..\tasks\$(_RoslynTargetDirectoryName)\</_RoslynTasksDirectory>
     <RoslynTasksAssembly>$(_RoslynTasksDirectory)Microsoft.Build.Tasks.CodeAnalysis.dll</RoslynTasksAssembly>
     <UseSharedCompilation Condition="'$(UseSharedCompilation)' == ''">true</UseSharedCompilation>

--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/Arm64DesktopCompilerArtifacts.targets
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/Arm64DesktopCompilerArtifacts.targets
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   Metalama: ARM64 desktop compiler artifacts for inclusion in the main Metalama.Compiler package (#104).
-  This is a variant of DesktopCompilerArtifacts.targets that collects ARM64-specific binaries.
+  This is a variant of DesktopCompilerArtifacts.targets that collects binaries from the ARM64 compiler
+  build outputs (csc-arm64, VBCSCompiler-arm64). It includes multi-arch DiaSymReader native binaries
+  (amd64, arm64, x86) required for PDB support, shared managed assemblies, and ARM64-native executables.
 -->
 <Project>
 

--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/Arm64DesktopCompilerArtifacts.targets
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/Arm64DesktopCompilerArtifacts.targets
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Metalama: ARM64 desktop compiler artifacts for inclusion in the main Metalama.Compiler package (#104).
+  This is a variant of DesktopCompilerArtifacts.targets that collects ARM64-specific binaries.
+-->
+<Project>
+
+  <Target Name="InitializeArm64DesktopCompilerArtifacts" Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+    <ItemGroup>
+
+      <Arm64DesktopCompilerArtifact Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis\$(Configuration)\netstandard2.0\Microsoft.CodeAnalysis.dll" />
+      <Arm64DesktopCompilerArtifact Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CSharp\$(Configuration)\netstandard2.0\Microsoft.CodeAnalysis.CSharp.dll" />
+      <Arm64DesktopCompilerArtifact Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler\$(Configuration)\netstandard2.0\Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler.dll" />
+      <Arm64DesktopCompilerArtifact Include="$(ArtifactsBinDir)csc-arm64\$(Configuration)\net472\Microsoft.DiaSymReader.Native.amd64.dll" />
+      <Arm64DesktopCompilerArtifact Include="$(ArtifactsBinDir)csc-arm64\$(Configuration)\net472\Microsoft.DiaSymReader.Native.arm64.dll" />
+      <Arm64DesktopCompilerArtifact Include="$(ArtifactsBinDir)csc-arm64\$(Configuration)\net472\Microsoft.DiaSymReader.Native.x86.dll" />
+      <Arm64DesktopCompilerArtifact Include="$(ArtifactsBinDir)csc-arm64\$(Configuration)\net472\csc.exe" />
+      <Arm64DesktopCompilerArtifact Include="$(ArtifactsBinDir)csc-arm64\$(Configuration)\net472\csc.exe.config" />
+      <Arm64DesktopCompilerArtifact Include="$(ArtifactsBinDir)csc-arm64\$(Configuration)\net472\csc.rsp" />
+
+      <Arm64DesktopCompilerArtifact Include="$(ArtifactsBinDir)VBCSCompiler-arm64\$(Configuration)\net472\VBCSCompiler.exe" />
+      <Arm64DesktopCompilerArtifact Include="$(ArtifactsBinDir)VBCSCompiler-arm64\$(Configuration)\net472\VBCSCompiler.exe.config" />
+      <Arm64DesktopCompilerArtifact Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\net472\Microsoft.Build.Tasks.CodeAnalysis.dll" />
+      <Arm64DesktopCompilerArtifact Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\net472\Microsoft.Managed.Core.CurrentVersions.targets" />
+      <Arm64DesktopCompilerArtifact Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\net472\Microsoft.Managed.Core.targets" />
+      <Arm64DesktopCompilerArtifact Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\net472\Microsoft.CSharp.Core.targets" />
+
+      <!-- System.* dependencies from the csi output (same as AnyCpu) -->
+      <Arm64DesktopCompilerArtifact Include="$(ArtifactsBinDir)csi\$(Configuration)\net472\System.*.dll" />
+
+      <!-- Satellite assemblies -->
+      <Arm64DesktopCompilerResourceArtifact Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.resources.dll" />
+      <Arm64DesktopCompilerResourceArtifact Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CSharp\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.CSharp.resources.dll" />
+      <Arm64DesktopCompilerResourceArtifact Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\net472\**\Microsoft.Build.Tasks.CodeAnalysis.resources.dll" />
+    </ItemGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
## Summary

Fixes #104: Compiler is running as x64 under .NET Framework on ARM

- Include ARM64-native `csc.exe` and `VBCSCompiler.exe` in the main `Metalama.Compiler` NuGet package under `tasks/net472-arm64/`
- Update `Metalama.Compiler.props` to detect ARM64 via `PROCESSOR_ARCHITECTURE` environment variable and select the native binaries instead of the AnyCPU ones that run under x64 emulation
- Add `Arm64DesktopCompilerArtifacts.targets` to define the ARM64 artifact collection for packaging

## Changes

### `Metalama.Compiler.Package.csproj` (AnyCpu)
- Added ARM64 project references (`csc-arm64`, `VBCSCompiler-arm64`) conditioned on `net472`
- Added ARM64 binaries to `_GetFilesToPackage` target, placed in `tasks/net472-arm64/`
- Import new `Arm64DesktopCompilerArtifacts.targets`

### `Metalama.Compiler.props` (build)
- Detect ARM64 via `PROCESSOR_ARCHITECTURE` environment variable
- When running under .NET Framework on ARM64 Windows, use `net472-arm64` directory instead of `net472`

### `Arm64DesktopCompilerArtifacts.targets` (new)
- Collects compiler binaries from the ARM64 build outputs (csc-arm64, VBCSCompiler-arm64), including multi-arch DiaSymReader native binaries for PDB support

## Checklist

- [x] Implement fix (include ARM64 in package, update .props)
- [x] Build succeeds with `dotnet build` (0 warnings, 0 errors)
- [x] Address review feedback (PROCESSOR_ARCHITECTURE, clarify .targets comment)
- [x] Manual testing on ARM64 Windows machine (cannot be done in CI)

## Test plan

- [x] Install the package on an ARM64 Windows machine
- [x] Build a project using Visual Studio (which uses .NET Framework MSBuild)
- [x] Verify VBCSCompiler runs as native ARM64 (not x64 emulation) via Task Manager architecture column