### PR TITLE
Add MetalamaEmitCompilerTransformedFiles as CompilerVisibleProperty

### DIFF
--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/AnyCpu/build/Metalama.Compiler.props
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/AnyCpu/build/Metalama.Compiler.props
@@ -52,6 +52,7 @@
   
   <ItemGroup>
     <CompilerVisibleProperty Include="MetalamaDebugTransformedCode" />
+    <CompilerVisibleProperty Include="MetalamaEmitCompilerTransformedFiles" />
     <CompilerVisibleProperty Include="MetalamaCompilerTransformerOrder" />
     <CompilerVisibleProperty Include="MetalamaCompilerTransformedFilesOutputPath" />
     <CompilerVisibleProperty Include="MetalamaDebugCompiler" />


### PR DESCRIPTION
## Summary

Fixes #171.

`MetalamaEmitCompilerTransformedFiles` was not declared as a `<CompilerVisibleProperty>` in `Metalama.Compiler.props`, so Roslyn never surfaced it to Metalama's analyzer/source-generator via `AnalyzerConfigOptions`. This caused `WriteTransformedFiles` to always return `false` in the analyzer path, meaning the code formatter never ran when emitting transformed files — producing malformed C# with missing whitespace.

**Change**: Add `<CompilerVisibleProperty Include="MetalamaEmitCompilerTransformedFiles" />` to `AnyCpu/build/Metalama.Compiler.props` alongside the existing compiler-visible properties.

## Checklist

- [x] Understand the issue
- [x] Implement fix
- [x] Build passes (`Build.ps1 build`)
- [ ] Finalize (mark ready, request review)

## Note

The issue also mentions a Framework-side change (adding `MetalamaEmitCompilerTransformedFiles` to `MSBuildPropertyNames.All` for cache-invalidation correctness). That change belongs in the `Metalama` repo and is tracked separately.