### PR TITLE
Restore Windows analyzer bundle + keep installed-SDK fallback (#180)

### DIFF
--- a/eng-Metalama/DownloadNetSdkAnalyzers/DownloadNetSdkAnalyzers.csproj
+++ b/eng-Metalama/DownloadNetSdkAnalyzers/DownloadNetSdkAnalyzers.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NuGet.Versioning" Version="6.10.1" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />
+  </ItemGroup>
+  
+</Project>

--- a/eng-Metalama/DownloadNetSdkAnalyzers/DownloadNetSdkAnalyzers.sln
+++ b/eng-Metalama/DownloadNetSdkAnalyzers/DownloadNetSdkAnalyzers.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33723.286
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DownloadNetSdkAnalyzers", "DownloadNetSdkAnalyzers.csproj", "{F6374A42-4E2D-4A82-985E-6A110C2B98BD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F6374A42-4E2D-4A82-985E-6A110C2B98BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6374A42-4E2D-4A82-985E-6A110C2B98BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F6374A42-4E2D-4A82-985E-6A110C2B98BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F6374A42-4E2D-4A82-985E-6A110C2B98BD}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {90E90CDC-A8CE-4422-AF66-6AB8E29CADA8}
+	EndGlobalSection
+EndGlobal

--- a/eng-Metalama/DownloadNetSdkAnalyzers/HttpClientExtensions.cs
+++ b/eng-Metalama/DownloadNetSdkAnalyzers/HttpClientExtensions.cs
@@ -1,0 +1,16 @@
+﻿namespace DownloadNetSdkAnalyzers;
+
+public static class HttpClientExtensions
+{
+    public static async Task<Stream> GetSeekableStreamAsync(this HttpClient client, string requestUriString)
+    {
+        var requestUri = new Uri(requestUriString);
+        var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        request.Headers.Host = requestUri.Host;
+
+        var response = await client.SendAsync(request);
+        var stream = await response.Content.ReadAsStreamAsync();
+
+        return stream;
+    }
+}

--- a/eng-Metalama/DownloadNetSdkAnalyzers/NetSdkDownloader.cs
+++ b/eng-Metalama/DownloadNetSdkAnalyzers/NetSdkDownloader.cs
@@ -1,0 +1,98 @@
+﻿using System.IO.Compression;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using NuGet.Versioning;
+
+namespace DownloadNetSdkAnalyzers;
+
+sealed class NetSdkDownloader : IDisposable
+{
+    private static readonly HttpClient s_httpClient = new();
+
+    private readonly ZipArchive _archive;
+
+    public SemanticVersion SdkVersion { get; }
+
+    static NetSdkDownloader()
+    {
+        s_httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("PostSharp.Engineering");
+        s_httpClient.Timeout = TimeSpan.FromMinutes(10);
+    }
+
+    private NetSdkDownloader(ZipArchive archive, SemanticVersion sdkVersion)
+    {
+        this._archive = archive;
+        SdkVersion = sdkVersion;
+    }
+
+    public static async Task<NetSdkDownloader> CreateAsync(string url, SemanticVersion sdkVersion)
+    {
+        Stream? stream = null;
+        var retries = 0;
+        var maxRetries = 3;
+        var delay = TimeSpan.FromSeconds(5);
+
+        while (stream == null)
+        {
+            try
+            {
+                stream = await s_httpClient.GetSeekableStreamAsync(url);
+            }
+            catch (Exception)
+            {
+                if (retries > maxRetries)
+                {
+                    throw;
+                }
+
+                await Task.Delay(delay);
+                retries++;
+                delay *= 2;
+            }
+        }
+
+        var archive = new ZipArchive(stream);
+
+        return new(archive, sdkVersion);
+    }
+
+    public SemanticVersion GetCodeAnalysisVersion()
+    {
+        var codeAnalysisEntry = _archive.Entries.Single(entry => Regex.IsMatch(entry.FullName, "sdk/[^/]+/Roslyn/bincore/Microsoft.CodeAnalysis.dll"));
+
+        using var codeAnalysisStream = codeAnalysisEntry.Open();
+
+        // MetadataLoadContext requires a seekable stream, so copy the assembly to MemoryStream.
+        var codeAnalysisMemoryStream = new MemoryStream();
+        codeAnalysisStream.CopyTo(codeAnalysisMemoryStream);
+
+        var resolver = new PathAssemblyResolver(new[] { typeof(object).Assembly.Location, Path.Combine(Path.GetDirectoryName(typeof(object).Assembly.Location)!, "System.Runtime.dll") });
+        var mlc = new MetadataLoadContext(resolver, typeof(object).Assembly.GetName().Name);
+        var assembly = mlc.LoadFromStream(codeAnalysisMemoryStream);
+
+        return SemanticVersion.Parse((string)assembly.GetCustomAttributesData().Single(a => GetTypeOrNull(a)?.FullName == typeof(AssemblyInformationalVersionAttribute).FullName).ConstructorArguments.Single().Value!);
+
+        static Type? GetTypeOrNull(CustomAttributeData attributeData)
+        {
+            try
+            {
+                return attributeData.AttributeType;
+            }
+            catch (FileNotFoundException)
+            {
+                // Could not load some dependent assembly, but we don't care about such attributes.
+                return null;
+            }
+        }
+    }
+
+    public IEnumerable<ZipArchiveEntry> GetAnalyzers()
+        => _archive.Entries.Where(entry =>
+            (entry.FullName.Contains("/analyzers/", StringComparison.Ordinal)
+             || entry.FullName.Contains("/source-generators/", StringComparison.Ordinal))
+            && entry.Name.EndsWith(".dll", StringComparison.Ordinal)
+            && !entry.Name.EndsWith(".resources.dll", StringComparison.Ordinal)
+            && entry.Name != "System.Collections.Immutable.dll");
+
+    public void Dispose() => _archive.Dispose();
+}

--- a/eng-Metalama/DownloadNetSdkAnalyzers/NetSdkReleaseConverters.cs
+++ b/eng-Metalama/DownloadNetSdkAnalyzers/NetSdkReleaseConverters.cs
@@ -1,0 +1,62 @@
+﻿using NuGet.Versioning;
+using System.Text.Json.Serialization;
+using System.Text.Json;
+
+namespace DownloadNetSdkAnalyzers;
+
+class SemanticVersionConverter : JsonConverter<SemanticVersion>
+{
+    public override SemanticVersion? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        => SemanticVersion.Parse(reader.GetString()!);
+
+    public override void Write(Utf8JsonWriter writer, SemanticVersion value, JsonSerializerOptions options)
+        => writer.WriteStringValue(value.ToString());
+}
+
+class SemanticVersionDictionaryKeyConverterFactory : JsonConverterFactory
+{
+    public override bool CanConvert(Type typeToConvert)
+    {
+        return typeToConvert.IsGenericType
+            && typeToConvert.GetGenericTypeDefinition() == typeof(SortedDictionary<,>)
+            && typeToConvert.GenericTypeArguments[0] == typeof(SemanticVersion);
+    }
+
+    public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        => (JsonConverter)Activator.CreateInstance(typeof(Converter<>).MakeGenericType(typeToConvert.GenericTypeArguments[1]))!;
+
+    class Converter<TValue> : JsonConverter<SortedDictionary<SemanticVersion, TValue>>
+    {
+        public override SortedDictionary<SemanticVersion, TValue>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var stringDictionaryType = typeof(SortedDictionary<string, TValue>);
+            var dictionaryConverter = (JsonConverter<SortedDictionary<string, TValue>>)options.GetConverter(stringDictionaryType);
+
+            var stringDictionary = dictionaryConverter.Read(ref reader, stringDictionaryType, options);
+
+            var result = new SortedDictionary<SemanticVersion, TValue>();
+
+            foreach (var kvp in stringDictionary!)
+            {
+                result.Add(SemanticVersion.Parse(kvp.Key), kvp.Value);
+            }
+
+            return result;
+        }
+
+        public override void Write(Utf8JsonWriter writer, SortedDictionary<SemanticVersion, TValue> value, JsonSerializerOptions options)
+        {
+            var stringDictionaryType = typeof(SortedDictionary<string, TValue>);
+            var dictionaryConverter = (JsonConverter<SortedDictionary<string, TValue>>)options.GetConverter(stringDictionaryType);
+
+            var stringDictionary = new SortedDictionary<string, TValue>();
+
+            foreach (var kvp in value)
+            {
+                stringDictionary.Add(kvp.Key.ToString(), kvp.Value);
+            }
+
+            dictionaryConverter.Write(writer, stringDictionary, options);
+        }
+    }
+}

--- a/eng-Metalama/DownloadNetSdkAnalyzers/NetSdkReleaseInfo.cs
+++ b/eng-Metalama/DownloadNetSdkAnalyzers/NetSdkReleaseInfo.cs
@@ -33,7 +33,7 @@ static class NetSdkReleaseInfo
 
     private static async Task<KeyValuePair<SemanticVersion, NetSdkRelease>> GetLatestSdkForRoslynVersionAsync(SemanticVersion requestedRoslynVersion)
     {
-        // TODO: make this more efficient by not dowloading releases-index.json and all the releases.json every time?
+        // TODO: make this more efficient by not downloading releases-index.json and all the releases.json every time?
 
         var netSdkReleasesPath = "net-sdk-releases.json";
 

--- a/eng-Metalama/DownloadNetSdkAnalyzers/NetSdkReleaseInfo.cs
+++ b/eng-Metalama/DownloadNetSdkAnalyzers/NetSdkReleaseInfo.cs
@@ -1,0 +1,107 @@
+﻿using System.Net.Http.Json;
+using System.Text.Json;
+using NuGet.Versioning;
+
+namespace DownloadNetSdkAnalyzers;
+
+static class NetSdkReleaseInfo
+{
+    private const string ReleasesIndexUrl = "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json";
+
+    static readonly HttpClient s_httpClient = new();
+
+    static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.KebabCaseLower,
+        Converters = { new SemanticVersionConverter(), new SemanticVersionDictionaryKeyConverterFactory() },
+        WriteIndented = true,
+    };
+
+    public static async Task<NetSdkDownloader> GetLatestSdkDownloaderForRoslynVersionAsync(SemanticVersion requestedRoslynVersion)
+    {
+        var (foundReleaseVersion, foundRelease) = await GetLatestSdkForRoslynVersionAsync(requestedRoslynVersion);
+
+        return await NetSdkDownloader.CreateAsync(foundRelease.SdkZipUrl, foundReleaseVersion);
+    }
+
+    public static async Task<SemanticVersion> GetLatestSdkVersionForRoslynVersionAsync(SemanticVersion requestedRoslynVersion)
+    {
+        var (foundReleaseVersion, _) = await GetLatestSdkForRoslynVersionAsync(requestedRoslynVersion);
+
+        return foundReleaseVersion;
+    }
+
+    private static async Task<KeyValuePair<SemanticVersion, NetSdkRelease>> GetLatestSdkForRoslynVersionAsync(SemanticVersion requestedRoslynVersion)
+    {
+        // TODO: make this more efficient by not dowloading releases-index.json and all the releases.json every time?
+
+        var netSdkReleasesPath = "net-sdk-releases.json";
+
+        NetSdkReleasesDocument? netSdkReleases = null;
+
+        if (File.Exists(netSdkReleasesPath))
+        {
+            using var stream = File.OpenRead(netSdkReleasesPath);
+
+            try
+            {
+                netSdkReleases = JsonSerializer.Deserialize<NetSdkReleasesDocument>(stream, s_jsonOptions)!;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex.Message);
+            }
+        }
+
+        if (netSdkReleases == null)
+        {
+            netSdkReleases = new(new());
+        }
+
+        var releasesIndex = await s_httpClient.GetFromJsonAsync<ReleasesIndexDocument>(ReleasesIndexUrl, s_jsonOptions);
+
+        // The four most recent .Net releases should be sufficient: preview (e.g. 9.0), current LTS (8.0), out-of support (7.0) and the previous LTS (6.0).
+        var channels = releasesIndex!.Channels.Take(4);
+
+        var change = false;
+
+        foreach (var channel in channels)
+        {
+            var releases = await s_httpClient.GetFromJsonAsync<ReleasesDocument>(channel.ReleasesJsonUrl, s_jsonOptions);
+
+            foreach (var release in releases!.Releases)
+            {
+                var sdkVersion = release.Sdk.VersionDisplay;
+
+                // Only consider pre-release versions if the .Net version is still in preview.
+                if (sdkVersion.IsPrerelease && channel.SupportPhase is not ("preview" or "go-live"))
+                {
+                    continue;
+                }
+
+                if (!netSdkReleases.Releases.ContainsKey(sdkVersion))
+                {
+                    var sdkZip = release.Sdk.Files.Single(file => file.Name == "dotnet-sdk-win-x64.zip");
+
+                    using var downloader = await NetSdkDownloader.CreateAsync(sdkZip.Url, sdkVersion);
+
+                    netSdkReleases.Releases.Add(
+                        sdkVersion, new(sdkZip.Url, downloader.GetCodeAnalysisVersion()));
+
+                    change = true;
+                }
+            }
+        }
+
+        if (change)
+        {
+            using var stream = File.Create(netSdkReleasesPath);
+
+            JsonSerializer.Serialize(stream, netSdkReleases, s_jsonOptions);
+        }
+
+        // Only consider preview SDKs if the requested version is also preview.
+        return netSdkReleases.Releases
+            .Last(kvp => (!kvp.Key.IsPrerelease || requestedRoslynVersion.IsPrerelease) && kvp.Value.RoslynVersion <= requestedRoslynVersion);
+    }
+}

--- a/eng-Metalama/DownloadNetSdkAnalyzers/NetSdkReleaseModels.cs
+++ b/eng-Metalama/DownloadNetSdkAnalyzers/NetSdkReleaseModels.cs
@@ -1,0 +1,26 @@
+﻿using NuGet.Versioning;
+using System.Text.Json.Serialization;
+
+namespace DownloadNetSdkAnalyzers;
+
+record NetSdkReleasesDocument(SortedDictionary<SemanticVersion, NetSdkRelease> Releases);
+
+record NetSdkRelease(string SdkZipUrl, SemanticVersion RoslynVersion);
+
+record ReleasesDocument(IList<Release> Releases);
+
+record Release(Sdk Sdk);
+
+record Sdk(SemanticVersion VersionDisplay, IList<SdkFile> Files);
+
+record SdkFile(string Name, string Url);
+
+record ReleasesIndexDocument(
+    [property: JsonPropertyName("releases-index")] IList<Channel> Channels);
+
+record Channel(
+    string ChannelVersion,
+    SemanticVersion LatestRelease,
+    DateOnly LatestReleaseDate,
+    string SupportPhase,
+    [property: JsonPropertyName("releases.json")] string ReleasesJsonUrl);

--- a/eng-Metalama/DownloadNetSdkAnalyzers/Program.cs
+++ b/eng-Metalama/DownloadNetSdkAnalyzers/Program.cs
@@ -1,0 +1,50 @@
+﻿using DownloadNetSdkAnalyzers;
+using NuGet.Versioning;
+
+var requestedRoslynVersion = SemanticVersion.Parse(args[0]);
+
+if (args is [_, "-sdk-version", ..])
+{
+    Console.WriteLine(await NetSdkReleaseInfo.GetLatestSdkVersionForRoslynVersionAsync(requestedRoslynVersion));
+    return;
+}
+
+using var sdkDownloader = await NetSdkReleaseInfo.GetLatestSdkDownloaderForRoslynVersionAsync(requestedRoslynVersion);
+
+var directory = Path.Combine(Path.GetTempPath(), "Metalama", "SdkAnalyzers", sdkDownloader.SdkVersion.ToString());
+
+var completedFilePath = Path.Combine(directory, ".completed");
+
+bool shouldSave = true;
+
+if (Directory.Exists(directory))
+{
+    if (File.Exists(completedFilePath))
+    {
+        shouldSave = false;
+    }
+    else
+    {
+        // Attempt to delete the directory and recreate it from scratch.
+        Directory.Delete(directory, recursive: true);
+    }
+}
+
+if (shouldSave)
+{
+    Directory.CreateDirectory(directory);
+
+    foreach (var entry in sdkDownloader.GetAnalyzers())
+    {
+        var analyzerPath = Path.Combine(directory, entry.Name);
+
+        using var downloadAnalyzerStream = entry.Open();
+        using var savingAnalyzerStream = File.OpenWrite(analyzerPath);
+
+        await downloadAnalyzerStream.CopyToAsync(savingAnalyzerStream);
+    }
+
+    File.WriteAllText(completedFilePath, "completed");
+}
+
+Console.WriteLine(directory);

--- a/eng-Metalama/DownloadNetSdkAnalyzers/net-sdk-releases.json
+++ b/eng-Metalama/DownloadNetSdkAnalyzers/net-sdk-releases.json
@@ -1,0 +1,544 @@
+{
+  "releases": {
+    "10.0.100": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100/dotnet-sdk-10.0.100-win-x64.zip",
+      "roslyn-version": "5.0.0-2.25523.111"
+    },
+    "10.0.100-preview.1": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/fafaef8c-2fef-45d9-bc1d-df26963df6ba/94fee230c7e4fc7459fcd019ea1a7675/dotnet-sdk-10.0.100-preview.1.25120.13-win-x64.zip",
+      "roslyn-version": "4.14.0-1.25070.2"
+    },
+    "10.0.100-preview.2": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/86371ea8-4e6d-4269-98e6-d9768d9fd630/fba4a5b8d540679e7921b1a90ddb2e24/dotnet-sdk-10.0.100-preview.2.25164.34-win-x64.zip",
+      "roslyn-version": "4.14.0-3.25126.1"
+    },
+    "10.0.100-preview.3": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.3.25201.16/dotnet-sdk-10.0.100-preview.3.25201.16-win-x64.zip",
+      "roslyn-version": "4.14.0-3.25179.1"
+    },
+    "10.0.100-preview.4": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.4.25258.110/dotnet-sdk-10.0.100-preview.4.25258.110-win-x64.zip",
+      "roslyn-version": "5.0.0-1.25258.110"
+    },
+    "10.0.100-preview.5": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.5.25277.114/dotnet-sdk-10.0.100-preview.5.25277.114-win-x64.zip",
+      "roslyn-version": "5.0.0-1.25277.114"
+    },
+    "10.0.100-preview.6": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.6.25358.103/dotnet-sdk-10.0.100-preview.6.25358.103-win-x64.zip",
+      "roslyn-version": "5.0.0-1.25358.103"
+    },
+    "10.0.100-preview.7": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.7.25380.108/dotnet-sdk-10.0.100-preview.7.25380.108-win-x64.zip",
+      "roslyn-version": "5.0.0-2.25380.108"
+    },
+    "10.0.100-rc.1": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-rc.1.25451.107/dotnet-sdk-10.0.100-rc.1.25451.107-win-x64.zip",
+      "roslyn-version": "5.0.0-2.25451.107"
+    },
+    "10.0.100-rc.2": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-rc.2.25502.107/dotnet-sdk-10.0.100-rc.2.25502.107-win-x64.zip",
+      "roslyn-version": "5.0.0-2.25502.107"
+    },
+    "10.0.101": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.101/dotnet-sdk-10.0.101-win-x64.zip",
+      "roslyn-version": "5.0.0-2.25569.105"
+    },
+    "10.0.102": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.102/dotnet-sdk-10.0.102-win-x64.zip",
+      "roslyn-version": "5.0.0-2.25612.105"
+    },
+    "10.0.103": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.103/dotnet-sdk-10.0.103-win-x64.zip",
+      "roslyn-version": "5.0.0-2.26075.103"
+    },
+    "10.0.200": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.200/dotnet-sdk-10.0.200-win-x64.zip",
+      "roslyn-version": "5.3.0-2.26119.122"
+    },
+    "10.0.201": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.201/dotnet-sdk-10.0.201-win-x64.zip",
+      "roslyn-version": "5.3.0-2.26153.122"
+    },
+    "10.0.202": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.202/dotnet-sdk-10.0.202-win-x64.zip",
+      "roslyn-version": "5.3.0-2.26180.118"
+    },
+    "10.0.203": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.203/dotnet-sdk-10.0.203-win-x64.zip",
+      "roslyn-version": "5.3.0-2.26219.105"
+    },
+    "10.0.300": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.300/dotnet-sdk-10.0.300-win-x64.zip",
+      "roslyn-version": "5.6.0-2.26230.102"
+    },
+    "11.0.100-preview.1": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.1.26104.118/dotnet-sdk-11.0.100-preview.1.26104.118-win-x64.zip",
+      "roslyn-version": "5.4.0-2.26104.118"
+    },
+    "11.0.100-preview.2": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.2.26159.112/dotnet-sdk-11.0.100-preview.2.26159.112-win-x64.zip",
+      "roslyn-version": "5.6.0-2.26159.112"
+    },
+    "11.0.100-preview.3": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-x64.zip",
+      "roslyn-version": "5.7.0-1.26207.106"
+    },
+    "11.0.100-preview.4": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.4.26230.115/dotnet-sdk-11.0.100-preview.4.26230.115-win-x64.zip",
+      "roslyn-version": "5.7.0-1.26230.115"
+    },
+    "6.0.100": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/ca65b248-9750-4c2d-89e6-ef27073d5e95/05c682ca5498bfabc95985a4c72ac635/dotnet-sdk-6.0.100-win-x64.zip",
+      "roslyn-version": "4.0.0-6.21526.21"
+    },
+    "6.0.101": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/8e55ce37-9740-41b7-a758-f731043060da/4b8bfd4aad9d322bf501ca9e473e35c5/dotnet-sdk-6.0.101-win-x64.zip",
+      "roslyn-version": "4.0.1-1.21569.2"
+    },
+    "6.0.200": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/0cb33e31-4c3e-470f-bd40-ca582f583229/15c909eb3a9d20421771cab233af8cc1/dotnet-sdk-6.0.200-win-x64.zip",
+      "roslyn-version": "4.1.0-3.22075.3"
+    },
+    "6.0.201": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/5432b207-da43-4524-810c-563f1820d6b4/f5ca8777ecca3fd9dff35ca90502c960/dotnet-sdk-6.0.201-win-x64.zip",
+      "roslyn-version": "4.1.0-5.22116.13"
+    },
+    "6.0.202": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/b1461027-6daa-467d-aebe-6326343e5840/01656d95b28f16c53cd947a8072d004b/dotnet-sdk-6.0.202-win-x64.zip",
+      "roslyn-version": "4.1.0-5.22128.4"
+    },
+    "6.0.300": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/cc89c1f6-0d56-46fd-88f9-1fbd8ce074ec/753afbad1926cbc8d28aa4a2dd7d9d66/dotnet-sdk-6.0.300-win-x64.zip",
+      "roslyn-version": "4.2.0-4.22220.2"
+    },
+    "6.0.301": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/333eba0c-3242-48f3-a923-fdac5f219f77/342a4595101e3b4616360a7666459236/dotnet-sdk-6.0.301-win-x64.zip",
+      "roslyn-version": "4.2.0-4.22220.5"
+    },
+    "6.0.302": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/44d08222-aaa9-4d35-b24b-d0db03432ab7/52a4eb5922afd19e8e0d03e0dbbb41a0/dotnet-sdk-6.0.302-win-x64.zip",
+      "roslyn-version": "4.2.0-4.22220.5"
+    },
+    "6.0.400": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/8686fa48-b378-424e-908b-afbd66d6e120/2d75d5c3574fb5d917c5a3cd3f624287/dotnet-sdk-6.0.400-win-x64.zip",
+      "roslyn-version": "4.3.0-3.22365.10"
+    },
+    "6.0.401": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/aa0b6cf3-c5dc-40ff-8b2f-f2970ca7b9e3/5b4a9999ea41ca5897e01a3e0e1accad/dotnet-sdk-6.0.401-win-x64.zip",
+      "roslyn-version": "4.3.0-3.22415.1"
+    },
+    "6.0.402": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/554fb42f-36ae-4f2f-b7e1-6b447ebb1867/a512568a4574fc3494b73c187a5316d8/dotnet-sdk-6.0.402-win-x64.zip",
+      "roslyn-version": "4.3.0-3.22465.2"
+    },
+    "6.0.403": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/e4c38e2f-07a2-4ab7-9607-369dc406f0d5/d1bef72f340bb2f3fb10e5ec92561f21/dotnet-sdk-6.0.403-win-x64.zip",
+      "roslyn-version": "4.3.1-3.22505.12"
+    },
+    "6.0.404": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/6ad651e3-818f-4e00-bb14-e632e1cecdb9/a7228c4ef87b2b856231d0b97f775b4b/dotnet-sdk-6.0.404-win-x64.zip",
+      "roslyn-version": "4.3.1-3.22526.13"
+    },
+    "6.0.405": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/402ad1ea-e4a5-4582-8d74-1c2efd5907e6/2c8eb49494a3598b892681cab23be8ba/dotnet-sdk-6.0.405-win-x64.zip",
+      "roslyn-version": "4.3.1-3.22526.13"
+    },
+    "6.0.406": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/f16f4f87-539e-45c5-9955-50faebec8952/ecf58d052d15372aa01f389b79782c39/dotnet-sdk-6.0.406-win-x64.zip",
+      "roslyn-version": "4.3.1-3.22526.13"
+    },
+    "6.0.407": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/bfb61a9e-7931-4d37-926e-ccfb73b5d910/7bb8a55f3dab0fe28f7e7bf2f9c41aeb/dotnet-sdk-6.0.407-win-x64.zip",
+      "roslyn-version": "4.3.1-3.22526.13"
+    },
+    "6.0.408": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/ca13c6f1-3107-4cf8-991c-f70edc1c1139/a9f90579d827514af05c3463bed63c22/dotnet-sdk-6.0.408-win-x64.zip",
+      "roslyn-version": "4.3.1-3.22526.13"
+    },
+    "6.0.410": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/735f204c-3a63-464b-931a-a0439c9067a0/14389038ec984246ab803ae99cf22fbf/dotnet-sdk-6.0.410-win-x64.zip",
+      "roslyn-version": "4.3.1-3.22526.13"
+    },
+    "6.0.411": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/61f44f70-0f5a-4b89-ae95-b26c80567917/abac586ea20fb485702ea496fe83b9ee/dotnet-sdk-6.0.411-win-x64.zip",
+      "roslyn-version": "4.3.1-3.22526.13"
+    },
+    "6.0.412": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/28be1206-08c5-44bb-ab3d-6775bc03b392/2146d7b8060998ea83d381ee80471557/dotnet-sdk-6.0.412-win-x64.zip",
+      "roslyn-version": "4.3.1-3.22526.13"
+    },
+    "6.0.413": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/3d28b406-bdbd-423e-a173-015215ae83d5/abf5701bb34a153e073409858758eea1/dotnet-sdk-6.0.413-win-x64.zip",
+      "roslyn-version": "4.3.1-3.22526.13"
+    },
+    "6.0.414": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/c226e396-07e9-4ce6-a6d2-96c867db596c/84a7aaf08f4c038d0f142c516d529bcc/dotnet-sdk-6.0.414-win-x64.zip",
+      "roslyn-version": "4.3.1-3.22526.13"
+    },
+    "6.0.415": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/38487782-aa7b-40a8-9de4-18e93344d21b/6fdd1c8b3b4e673f8ba7f2d97283984b/dotnet-sdk-6.0.415-win-x64.zip",
+      "roslyn-version": "4.3.1-3.22526.13"
+    },
+    "6.0.416": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/e5f3c5bd-fb2d-4070-9893-fa3e852c5545/49dc01b583c1007561a3e51f898abe77/dotnet-sdk-6.0.416-win-x64.zip",
+      "roslyn-version": "4.3.1-3.22526.13"
+    },
+    "6.0.417": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/9fdcd0fd-467c-43ee-b118-1f163533e8f1/f1031bccbf9327fc69f4bf5826d557f3/dotnet-sdk-6.0.417-win-x64.zip",
+      "roslyn-version": "4.3.1-3.22526.13"
+    },
+    "6.0.418": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/a33e6436-92cf-4659-9dfd-8ccbfde6255e/39f2eb8d138db0053747e1e530b56475/dotnet-sdk-6.0.418-win-x64.zip",
+      "roslyn-version": "4.3.1-3.22526.13"
+    },
+    "6.0.419": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/5216ba35-4818-4ccc-bfea-423167b2c2e0/e879920a65ee5b5dc13d884d823b8469/dotnet-sdk-6.0.419-win-x64.zip",
+      "roslyn-version": "4.3.1-3.22526.13"
+    },
+    "6.0.420": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/98372669-0339-4a65-8a48-7f8b6426339a/204e48e8157b031ecb0149a44827863c/dotnet-sdk-6.0.420-win-x64.zip",
+      "roslyn-version": "4.3.1-3.22526.13"
+    },
+    "6.0.421": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/14804c03-4206-411a-80a5-8e26cd6ddcbc/e4e1e88d75be3a6f5c84ea3d39f60c19/dotnet-sdk-6.0.421-win-x64.zip",
+      "roslyn-version": "4.3.1-3.22526.13"
+    },
+    "6.0.422": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/078b7ea9-b26e-4c4e-80eb-3a79be9906d8/a20046f51d2e14c20ac4d5872f29d174/dotnet-sdk-6.0.422-win-x64.zip",
+      "roslyn-version": "4.3.1-3.22526.13"
+    },
+    "6.0.423": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/99a9fa70-dc10-4b3e-8f5e-9e88b322de31/03c298ff8e31897c16ad36618e3042e7/dotnet-sdk-6.0.423-win-x64.zip",
+      "roslyn-version": "4.3.1-3.22526.13"
+    },
+    "6.0.424": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/b298579b-5779-4a53-bd04-19749f22eb28/5e0f54a5a0de540dba50e8379a4e3ff7/dotnet-sdk-6.0.424-win-x64.zip",
+      "roslyn-version": "4.3.1-3.22526.13"
+    },
+    "6.0.425": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/2cd43980-3abc-47ea-898d-b10116d27890/be9d8a7809b43ce82cf441b6761836a3/dotnet-sdk-6.0.425-win-x64.zip",
+      "roslyn-version": "4.3.1-3.22526.13"
+    },
+    "6.0.427": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/493caf1f-df72-4ed8-b011-fd5c0a721dbc/b166ce2a487008737ccecb26d20c2a01/dotnet-sdk-6.0.427-win-x64.zip",
+      "roslyn-version": "4.3.1-3.22526.13"
+    },
+    "6.0.428": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/5b2c6cee-abe2-4734-a099-729a346205e7/b5776361ebee2e1eeed9be4aad944652/dotnet-sdk-6.0.428-win-x64.zip",
+      "roslyn-version": "4.3.1-3.22526.13"
+    },
+    "7.0.100": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/1fb808dc-d017-4460-94f8-bf1ac83e6cd8/756b301e714755e411b84684b885a516/dotnet-sdk-7.0.100-win-x64.zip",
+      "roslyn-version": "4.4.0-4.22520.11"
+    },
+    "7.0.101": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/25a8e07d-21fb-46fe-a21e-33c7972d4683/50ba527abe01a9619ace5d8cc2450b70/dotnet-sdk-7.0.101-win-x64.zip",
+      "roslyn-version": "4.4.0-6.22565.8"
+    },
+    "7.0.102": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/7c869d6e-b49e-4c52-b197-77fca05f0c69/f3b6fb63231c8ed6afc585da090d4595/dotnet-sdk-7.0.102-win-x64.zip",
+      "roslyn-version": "4.4.0-6.22580.4"
+    },
+    "7.0.201": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/0c86eee2-5ff4-405a-8698-efb9018ee3c5/5a20e7bbcd9f99bd4dd178689b14cbe3/dotnet-sdk-7.0.201-win-x64.zip",
+      "roslyn-version": "4.5.0-3.23070.7"
+    },
+    "7.0.202": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/e2f99985-b54a-43a2-85cf-cfc9a1e0a307/171339e000ade0b6e10c3cb010ed45ba/dotnet-sdk-7.0.202-win-x64.zip",
+      "roslyn-version": "4.5.0-6.23127.3"
+    },
+    "7.0.302": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/c973fb82-ecba-4bcc-b1cc-443d817b9472/f4426b15af724f4baf31a50d204d1ca7/dotnet-sdk-7.0.302-win-x64.zip",
+      "roslyn-version": "4.6.0-3.23212.2"
+    },
+    "7.0.304": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/8f08bebf-8851-4cb3-9a16-7e800004867a/38369e796f1c61272732532e5b7c4fc3/dotnet-sdk-7.0.304-win-x64.zip",
+      "roslyn-version": "4.6.0-3.23259.8"
+    },
+    "7.0.305": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/ca2298f8-7c39-4187-98e5-f1be30e5eee5/b76077aaf76b1751b77fd4574837a0ab/dotnet-sdk-7.0.305-win-x64.zip",
+      "roslyn-version": "4.6.0-3.23259.8"
+    },
+    "7.0.306": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/3c443568-43b0-40b1-bb5c-3a6d8cd31876/e7d6c5b176b1c985a5f972dbf2c721b3/dotnet-sdk-7.0.306-win-x64.zip",
+      "roslyn-version": "4.6.0-3.23259.8"
+    },
+    "7.0.400": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/fe18f87e-e319-4042-8ed4-307629293bec/9b35c7b563b4800403d17797b25e0b06/dotnet-sdk-7.0.400-win-x64.zip",
+      "roslyn-version": "4.7.0-3.23366.1"
+    },
+    "7.0.401": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/f712b4d0-6b4b-42eb-865a-0c42af79eac9/9db3934d73a826a6e898abc70f41085a/dotnet-sdk-7.0.401-win-x64.zip",
+      "roslyn-version": "4.7.0-3.23416.9"
+    },
+    "7.0.402": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/c981b201-3f0e-47e3-a1db-a5cd270f0441/ae3cf5c68d59df4b5c77ae716b91175e/dotnet-sdk-7.0.402-win-x64.zip",
+      "roslyn-version": "4.7.0-3.23416.9"
+    },
+    "7.0.403": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/81514d64-25fd-46ec-a0d1-648ca8b81d4e/b5416848b9ef1ffe5a3e323c62dc859d/dotnet-sdk-7.0.403-win-x64.zip",
+      "roslyn-version": "4.7.0-3.23465.3"
+    },
+    "7.0.404": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/4f4fc500-65a8-42ca-a70c-c7f8827e7bd0/b6bbe369a0f4c16382811399bdb4a435/dotnet-sdk-7.0.404-win-x64.zip",
+      "roslyn-version": "4.7.0-3.23517.17"
+    },
+    "7.0.405": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/2133b143-9c4f-4daa-99b0-34fa6035d67b/193ede446d922eb833f1bfe0239be3fc/dotnet-sdk-7.0.405-win-x64.zip",
+      "roslyn-version": "4.7.0-3.23517.17"
+    },
+    "7.0.406": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/fcb3a458-d679-4ec2-a3fa-0bcbc77da68a/3d08bf7e392f5e028459658d2c722ec1/dotnet-sdk-7.0.406-win-x64.zip",
+      "roslyn-version": "4.7.0-3.23517.17"
+    },
+    "7.0.407": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/d0136505-ccb0-40c4-9284-341995f520a4/2a9b648902014af699cc9f847d923d1e/dotnet-sdk-7.0.407-win-x64.zip",
+      "roslyn-version": "4.7.0-3.23517.17"
+    },
+    "7.0.408": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/da9fce82-fdcb-4ca0-b5f3-e7de48671af1/eb11d529902618d1c26823e1a82af2c4/dotnet-sdk-7.0.408-win-x64.zip",
+      "roslyn-version": "4.7.0-3.23517.17"
+    },
+    "7.0.409": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/aac15151-b6c2-4b9b-9838-b872c59e24c1/17e15ef9123b3d4b51469b6f02793b76/dotnet-sdk-7.0.409-win-x64.zip",
+      "roslyn-version": "4.7.0-3.23517.17"
+    },
+    "7.0.410": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/1c6cf2f4-25f6-4317-94ce-5be9c8ae167d/02364359ad16d626f9dcb55717bd6900/dotnet-sdk-7.0.410-win-x64.zip",
+      "roslyn-version": "4.7.0-3.23517.17"
+    },
+    "8.0.100": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/2b2d6133-c4f9-46dd-9ab6-86443a7f5783/340054e2ac7de2bff9eea73ec9d4995a/dotnet-sdk-8.0.100-win-x64.zip",
+      "roslyn-version": "4.8.0-3.23524.11"
+    },
+    "8.0.101": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/6902745c-34bd-4d66-8e84-d5b61a17dfb7/e61732b00f7e144e162d7e6914291f16/dotnet-sdk-8.0.101-win-x64.zip",
+      "roslyn-version": "4.8.0-7.23572.1"
+    },
+    "8.0.201": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/a98272cb-1559-46f8-9601-16a80827557e/c5cab2b6e195e8a8ee42ea484cca5f80/dotnet-sdk-8.0.201-win-x64.zip",
+      "roslyn-version": "4.9.0-3.24067.18"
+    },
+    "8.0.203": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/48a48c8c-911f-45f0-ba75-900c093ed7fc/610cf5bc0a3c4a70b4b3b9478c22b03f/dotnet-sdk-8.0.203-win-x64.zip",
+      "roslyn-version": "4.9.2-3.24129.6"
+    },
+    "8.0.204": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/bf435b42-3f28-45db-a666-6e95c4faefe7/23e0b703124347b51f53faf64c829287/dotnet-sdk-8.0.204-win-x64.zip",
+      "roslyn-version": "4.9.2-3.24129.6"
+    },
+    "8.0.300": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/6dd60d95-f5ae-414e-8259-b2a115e51714/c56f08471133d789dee9ffa52ddf5c1e/dotnet-sdk-8.0.300-win-x64.zip",
+      "roslyn-version": "4.10.0-3.24216.12"
+    },
+    "8.0.301": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/7ac2d880-2d57-4008-850e-4b42b829c354/e1c92cb3b6a85f53cab6fa55b14b49e3/dotnet-sdk-8.0.301-win-x64.zip",
+      "roslyn-version": "4.10.0-3.24216.12"
+    },
+    "8.0.302": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/5af098e1-e433-4fda-84af-3f54fd27c108/6bd1c6e48e64e64871957289023ca590/dotnet-sdk-8.0.302-win-x64.zip",
+      "roslyn-version": "4.10.0-3.24216.12"
+    },
+    "8.0.303": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/93d39941-31b3-4c50-b124-0de50d464fe5/93a0dddb827811ff50586cb361f613b0/dotnet-sdk-8.0.303-win-x64.zip",
+      "roslyn-version": "4.10.0-3.24314.14"
+    },
+    "8.0.401": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/346fb097-97c0-4c83-9af8-ab245644f9da/bf2c626621422428a7e09e0ead5b0747/dotnet-sdk-8.0.401-win-x64.zip",
+      "roslyn-version": "4.11.0-3.24365.8"
+    },
+    "8.0.402": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/89fd6f50-4374-4cbb-801a-a91ef010ac71/1dc547c0b649578322b05f38c1c66de6/dotnet-sdk-8.0.402-win-x64.zip",
+      "roslyn-version": "4.11.0-3.24365.8"
+    },
+    "8.0.403": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/fe458265-87fe-4cc8-baed-7ebf467aab39/2f62c4e56c20f867d28057d7fee9502e/dotnet-sdk-8.0.403-win-x64.zip",
+      "roslyn-version": "4.11.0-3.24468.6"
+    },
+    "8.0.404": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/c20bc0e0-7344-4fb9-9c9b-697e11537c7e/405231def9d620e5a0ee7e5ba0a8fe97/dotnet-sdk-8.0.404-win-x64.zip",
+      "roslyn-version": "4.11.0-3.24510.3"
+    },
+    "8.0.405": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/0b9ebc5d-c870-410f-b0f5-763468a0c340/a45cf691a7023cc9ae5e8b7ea9aaae2a/dotnet-sdk-8.0.405-win-x64.zip",
+      "roslyn-version": "4.11.0-3.24554.2"
+    },
+    "8.0.406": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/4e3954c2-f714-4c43-b49a-0ee07c7cf7b2/f644fc3a93b8cf88099385ae14bea068/dotnet-sdk-8.0.406-win-x64.zip",
+      "roslyn-version": "4.11.0-3.24554.2"
+    },
+    "8.0.407": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/bdee64da-426f-44fa-908a-80172ec6a8d3/7f5c9e2e759511b625f53e0692095263/dotnet-sdk-8.0.407-win-x64.zip",
+      "roslyn-version": "4.11.0-3.24554.2"
+    },
+    "8.0.408": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.408/dotnet-sdk-8.0.408-win-x64.zip",
+      "roslyn-version": "4.11.0-3.24554.2"
+    },
+    "8.0.409": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.409/dotnet-sdk-8.0.409-win-x64.zip",
+      "roslyn-version": "4.11.0-3.24554.2"
+    },
+    "8.0.410": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.410/dotnet-sdk-8.0.410-win-x64.zip",
+      "roslyn-version": "4.11.0-3.24554.2"
+    },
+    "8.0.411": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.411/dotnet-sdk-8.0.411-win-x64.zip",
+      "roslyn-version": "4.11.0-3.24554.2"
+    },
+    "8.0.412": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.412/dotnet-sdk-8.0.412-win-x64.zip",
+      "roslyn-version": "4.11.0-3.24554.2"
+    },
+    "8.0.413": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.413/dotnet-sdk-8.0.413-win-x64.zip",
+      "roslyn-version": "4.11.0-3.24554.2"
+    },
+    "8.0.414": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.414/dotnet-sdk-8.0.414-win-x64.zip",
+      "roslyn-version": "4.11.0-3.24554.2"
+    },
+    "8.0.415": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.415/dotnet-sdk-8.0.415-win-x64.zip",
+      "roslyn-version": "4.11.0-3.24554.2"
+    },
+    "8.0.416": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.416/dotnet-sdk-8.0.416-win-x64.zip",
+      "roslyn-version": "4.11.0-3.24554.2"
+    },
+    "8.0.417": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.417/dotnet-sdk-8.0.417-win-x64.zip",
+      "roslyn-version": "4.11.0-3.25569.22"
+    },
+    "8.0.418": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.418/dotnet-sdk-8.0.418-win-x64.zip",
+      "roslyn-version": "4.11.0-3.25569.22"
+    },
+    "8.0.419": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.419/dotnet-sdk-8.0.419-win-x64.zip",
+      "roslyn-version": "4.11.0-3.25569.22"
+    },
+    "8.0.420": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.420/dotnet-sdk-8.0.420-win-x64.zip",
+      "roslyn-version": "4.11.0-3.25569.22"
+    },
+    "8.0.421": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.421/dotnet-sdk-8.0.421-win-x64.zip",
+      "roslyn-version": "4.11.0-3.25569.22"
+    },
+    "9.0.100": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/c5650c11-6944-488c-9192-cbab3c199deb/059197c7e46969164e752eec107fbea1/dotnet-sdk-9.0.100-win-x64.zip",
+      "roslyn-version": "4.12.0-3.24523.4"
+    },
+    "9.0.100-preview.1": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/4c55bc67-e478-4fdc-abe3-08b8dd64f4e4/9cf46c3018f477a93a8498850e6c122b/dotnet-sdk-9.0.100-preview.1.24101.2-win-x64.zip",
+      "roslyn-version": "4.10.0-1.24067.21"
+    },
+    "9.0.100-preview.2": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/1e952733-b58e-4d72-808b-4b6cafec490e/04fbd6374d14a95bebdf500b47e12098/dotnet-sdk-9.0.100-preview.2.24157.14-win-x64.zip",
+      "roslyn-version": "4.10.0-3.24151.8"
+    },
+    "9.0.100-preview.3": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/b50c34cf-e50a-4e64-9bdc-cbd984d44acb/9cba57d4130ef9451e2a9ec218d2c83d/dotnet-sdk-9.0.100-preview.3.24204.13-win-x64.zip",
+      "roslyn-version": "4.10.0-3.24202.15"
+    },
+    "9.0.100-preview.4": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/5bb0c9db-5ddb-44e7-90d1-bf34c1ac688f/8ba52405d812250c4b31e81e94c62334/dotnet-sdk-9.0.100-preview.4.24267.66-win-x64.zip",
+      "roslyn-version": "4.11.0-2.24252.3"
+    },
+    "9.0.100-preview.5": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/b08c26a7-83de-4d9a-b4d7-d87942b6d35e/d6d973d0cfe914189692af1154690935/dotnet-sdk-9.0.100-preview.5.24307.3-win-x64.zip",
+      "roslyn-version": "4.11.0-3.24280.3"
+    },
+    "9.0.100-preview.6": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/a889b484-004a-4cc2-844d-d5040cea4193/292354e7dec9e3a55932afdb66719c80/dotnet-sdk-9.0.100-preview.6.24328.19-win-x64.zip",
+      "roslyn-version": "4.11.0-3.24324.9"
+    },
+    "9.0.100-preview.7": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/dee149e6-a8bd-4290-ac01-ca2740fde18a/bffedcce6bab8b98bdbc75201cfbc9ad/dotnet-sdk-9.0.100-preview.7.24407.12-win-x64.zip",
+      "roslyn-version": "4.12.0-1.24379.1"
+    },
+    "9.0.100-rc.1": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/0439a9c2-0190-4595-92b3-9e14822f4a84/5c83aaa1c16ed9f464a56fee5320e358/dotnet-sdk-9.0.100-rc.1.24452.12-win-x64.zip",
+      "roslyn-version": "4.12.0-2.24422.8"
+    },
+    "9.0.100-rc.2": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/af6bbccc-1d18-4bcb-aa3a-ce76f864f977/8ecffe6494804fb6c6be93488c58eef6/dotnet-sdk-9.0.100-rc.2.24474.11-win-x64.zip",
+      "roslyn-version": "4.12.0-3.24473.3"
+    },
+    "9.0.101": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.101/dotnet-sdk-9.0.101-win-x64.zip",
+      "roslyn-version": "4.12.0-3.24570.6"
+    },
+    "9.0.102": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.102/dotnet-sdk-9.0.102-win-x64.zip",
+      "roslyn-version": "4.12.0-3.24574.8"
+    },
+    "9.0.200": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-win-x64.zip",
+      "roslyn-version": "4.13.0-3.25072.11"
+    },
+    "9.0.202": {
+      "sdk-zip-url": "https://download.visualstudio.microsoft.com/download/pr/a16e9966-3076-4d6d-914e-6b8228444876/123e08ddbdf6da335a3b636e66375c87/dotnet-sdk-9.0.202-win-x64.zip",
+      "roslyn-version": "4.13.0-3.25155.17"
+    },
+    "9.0.203": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-win-x64.zip",
+      "roslyn-version": "4.13.0-3.25155.17"
+    },
+    "9.0.300": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.300/dotnet-sdk-9.0.300-win-x64.zip",
+      "roslyn-version": "4.14.0-3.25218.8"
+    },
+    "9.0.301": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.301/dotnet-sdk-9.0.301-win-x64.zip",
+      "roslyn-version": "4.14.0-3.25262.10"
+    },
+    "9.0.303": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.303/dotnet-sdk-9.0.303-win-x64.zip",
+      "roslyn-version": "4.14.0-3.25359.3"
+    },
+    "9.0.304": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.304/dotnet-sdk-9.0.304-win-x64.zip",
+      "roslyn-version": "4.14.0-3.25359.3"
+    },
+    "9.0.305": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.305/dotnet-sdk-9.0.305-win-x64.zip",
+      "roslyn-version": "4.14.0-3.25413.5"
+    },
+    "9.0.306": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.306/dotnet-sdk-9.0.306-win-x64.zip",
+      "roslyn-version": "4.14.0-3.25465.8"
+    },
+    "9.0.307": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.307/dotnet-sdk-9.0.307-win-x64.zip",
+      "roslyn-version": "4.14.0-3.25465.8"
+    },
+    "9.0.308": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.308/dotnet-sdk-9.0.308-win-x64.zip",
+      "roslyn-version": "4.14.0-3.25465.8"
+    },
+    "9.0.310": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.310/dotnet-sdk-9.0.310-win-x64.zip",
+      "roslyn-version": "4.14.0-3.26064.1"
+    },
+    "9.0.311": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.311/dotnet-sdk-9.0.311-win-x64.zip",
+      "roslyn-version": "4.14.0-3.26064.1"
+    },
+    "9.0.312": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.312/dotnet-sdk-9.0.312-win-x64.zip",
+      "roslyn-version": "4.14.0-3.26064.1"
+    },
+    "9.0.313": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.313/dotnet-sdk-9.0.313-win-x64.zip",
+      "roslyn-version": "4.14.0-3.26064.1"
+    },
+    "9.0.314": {
+      "sdk-zip-url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.314/dotnet-sdk-9.0.314-win-x64.zip",
+      "roslyn-version": "4.14.0-3.26064.1"
+    }
+  }
+}

--- a/src/Compilers/Core/Portable/CommandLine/CommandLineArguments.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommandLineArguments.cs
@@ -769,7 +769,7 @@ namespace Microsoft.CodeAnalysis
                         if (AnalyzerAssemblyRedirector.FindCompatibleAnalyzer(resolvedPath, metalamaRoslynVersion) is { } redirectedPath)
                         {
                             // Per-analyzer warning (no dedup across analyzers — they may resolve to different SDKs).
-                            var redirectedSdkVersion = AnalyzerAssemblyRedirector.TryExtractSdkVersionFromPath(redirectedPath) ?? "(unknown)";
+                            var redirectedSdkVersion = AnalyzerAssemblyRedirector.GetRedirectedAnalyzerSdkVersion(redirectedPath) ?? "(unknown)";
                             diagnostics?.Add(new DiagnosticInfo(
                                 MetalamaCompilerMessageProvider.Instance,
                                 (int)MetalamaErrorCode.WRN_AnalyzerAssembliesRedirected,

--- a/src/Compilers/Core/Portable/Microsoft.CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/Microsoft.CodeAnalysis.csproj
@@ -39,6 +39,20 @@
     </AssemblyAttribute>
   </ItemGroup>
 
+  <Target Name="AddDotnetSdkAssemblyAttribute" BeforeTargets="CoreGenerateAssemblyInfo">
+    <!-- HACK: Random configuration name to prevent 'The process cannot access the file' error. -->
+    <Exec Command="dotnet run -c CFG$([System.IO.Path]::GetRandomFileName()) $(RoslynVersion) -sdk-version" WorkingDirectory="..\..\..\..\eng-Metalama\DownloadNetSdkAnalyzers" ConsoleToMsBuild="true" StandardOutputImportance="low" StandardErrorImportance="low">
+      <Output TaskParameter="ConsoleOutput" PropertyName="DotnetSdkVersion" />
+    </Exec>
+
+    <ItemGroup>
+      <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+        <_Parameter1>DotnetSdkVersion</_Parameter1>
+        <_Parameter2>$(DotnetSdkVersion)</_Parameter2>
+      </AssemblyAttribute>
+    </ItemGroup>
+  </Target>
+
   <!-- </Metalama> -->
   <ItemGroup>
     <None Include="Operations\OperationInterfaces.xml" />

--- a/src/Metalama/Metalama.Compiler.CodeAnalysis/AnalyzerAssemblyRedirector.cs
+++ b/src/Metalama/Metalama.Compiler.CodeAnalysis/AnalyzerAssemblyRedirector.cs
@@ -337,7 +337,11 @@ internal static class AnalyzerAssemblyRedirector
             return null;
         }
 
-        var pathToRoot = assemblyDirectory!.Contains("bincore") ? "../../.." : "../..";
+        // Check the immediate parent directory name rather than substring-matching the
+        // full path, so a workspace path that happens to contain "bincore" doesn't
+        // misidentify the .NET Framework layout.
+        var isBinCore = string.Equals(Path.GetFileName(assemblyDirectory), "bincore", StringComparison.OrdinalIgnoreCase);
+        var pathToRoot = isBinCore ? "../../.." : "../..";
         var dir = FileUtilities.TryNormalizeAbsolutePath(Path.Combine(assemblyDirectory, pathToRoot, "sdkAnalyzers"))
                   ?? Path.GetFullPath(Path.Combine(assemblyDirectory, pathToRoot, "sdkAnalyzers"));
 

--- a/src/Metalama/Metalama.Compiler.CodeAnalysis/AnalyzerAssemblyRedirector.cs
+++ b/src/Metalama/Metalama.Compiler.CodeAnalysis/AnalyzerAssemblyRedirector.cs
@@ -7,8 +7,11 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Runtime.InteropServices;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Roslyn.Utilities;
 
@@ -16,13 +19,16 @@ namespace Metalama.Compiler;
 
 /// <summary>
 /// Resolves an SDK-shipped analyzer DLL whose Microsoft.CodeAnalysis dependency is
-/// newer than the Roslyn bundled with Metalama Compiler to a compatible older copy
-/// found in a side-by-side installed .NET SDK on the build host.
-///
-/// Replaces the previous design that bundled SDK analyzers in the package's
-/// <c>sdkAnalyzers/</c> folder. With modern .NET 10 SDKs shipping composite R2R
-/// analyzer DLLs (no IL fallback), bundling them in any form is no longer viable;
-/// the only place an IL copy reliably exists is inside another installed SDK.
+/// newer than the Roslyn bundled with Metalama Compiler to a compatible older copy.
+/// The copy is found in two places, tried in order:
+/// <list type="number">
+///   <item>The package's <c>sdkAnalyzers/</c> bundle (built from an LKG SDK on the
+///         Metalama.Compiler build host). Used when a PE inspection determines that
+///         the bundled DLL is loadable on the current platform.</item>
+///   <item>An installed .NET SDK on the build host. Used as a fallback when the
+///         bundle is missing or not loadable (e.g. running on Linux against a bundle
+///         of Windows-x64 R2R DLLs).</item>
+/// </list>
 /// See issue #180.
 /// </summary>
 internal static class AnalyzerAssemblyRedirector
@@ -33,8 +39,8 @@ internal static class AnalyzerAssemblyRedirector
     private static readonly string[] s_analyzerSubdirNames = { "analyzers", "source-generators" };
 
     // Cache is keyed by analyzer file name. The first analyzer that triggers a redirect
-    // pre-populates entries for every DLL in the SDK directory it landed in, so that
-    // transitive references (which share the file name) resolve to the same SDK and
+    // pre-populates entries for every DLL in the source directory (bundle or SDK), so that
+    // transitive references (which share the file name) resolve to the same source and
     // preserve the binary-compatible pair the .NET team coordinated.
     //
     // Collisions are possible if two unrelated analyzers share a file name; in practice
@@ -42,6 +48,18 @@ internal static class AnalyzerAssemblyRedirector
     // through this code path.
     private static readonly ConcurrentDictionary<string, string?> s_cache
         = new(StringComparer.OrdinalIgnoreCase);
+
+    // Bundle of analyzer DLLs shipped inside the Metalama.Compiler nupkg. Lazy because
+    // the path is computed from the loaded assembly location, which we'd rather not
+    // touch at static-init time on the netstandard2.0 build.
+    private static readonly Lazy<string?> s_bundledAnalyzersDirectory =
+        new(GetBundledAnalyzersDirectory, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    // The SDK version the bundle was built against; written to Microsoft.CodeAnalysis.dll
+    // as an AssemblyMetadata attribute by the AddDotnetSdkAssemblyAttribute MSBuild target.
+    // Used to populate the {redirectedSdkVersion} arg of LAMA0617 when the bundle is used.
+    private static readonly Lazy<string?> s_bundledSdkVersion =
+        new(GetBundledSdkVersion, LazyThreadSafetyMode.ExecutionAndPublication);
 
     /// <summary>
     /// Pre-resolves every SDK analyzer in <paramref name="analyzerReferences"/> that needs
@@ -102,7 +120,7 @@ internal static class AnalyzerAssemblyRedirector
 
             if (redirectedPath != null)
             {
-                var redirectedSdkVersion = TryExtractSdkVersionFromPath(redirectedPath) ?? "(unknown)";
+                var redirectedSdkVersion = GetRedirectedAnalyzerSdkVersion(redirectedPath) ?? "(unknown)";
                 diagnostics.Add(new DiagnosticInfo(
                     MetalamaCompilerMessageProvider.Instance,
                     (int)MetalamaErrorCode.WRN_AnalyzerAssembliesRedirected,
@@ -150,7 +168,13 @@ internal static class AnalyzerAssemblyRedirector
             return cached;
         }
 
-        var resolved = FindUncached(fileName, maxRoslynVersion);
+        // Bundle takes precedence over installed SDKs: when the bundle ships a
+        // platform-loadable copy of the requested analyzer, that's the version we
+        // know to be binary-compatible with our Roslyn (Metalama.Compiler built it).
+        // The SDK scan is the fallback for platforms where the bundle isn't loadable
+        // (Linux/macOS against Windows-x64 R2R) or when the bundle doesn't contain
+        // the requested file.
+        var resolved = TryGetBundledRedirect(fileName) ?? FindUncached(fileName, maxRoslynVersion);
         s_cache[fileName] = resolved;
 
         if (resolved != null)
@@ -241,6 +265,90 @@ internal static class AnalyzerAssemblyRedirector
         return true;
     }
 
+    private static string? TryGetBundledRedirect(string fileName)
+    {
+        if (s_bundledAnalyzersDirectory.Value is not { } dir)
+        {
+            return null;
+        }
+
+        var path = Path.Combine(dir, fileName);
+        return File.Exists(path) && IsLoadableOnCurrentPlatform(path) ? path : null;
+    }
+
+    /// <summary>
+    /// Decides whether the bundled DLL at <paramref name="filePath"/> can be loaded by
+    /// the running compiler process. Pure-IL assemblies are portable; assemblies with
+    /// native code (R2R composite or mixed-mode) are platform-specific and must match
+    /// both OS and architecture. The Metalama.Compiler bundle is built on Windows, so
+    /// native code in it is always Windows-targeting.
+    /// </summary>
+    private static bool IsLoadableOnCurrentPlatform(string filePath)
+    {
+        using var stream = File.OpenRead(filePath);
+        using var pe = new PEReader(stream);
+        if (!pe.HasMetadata)
+        {
+            return false;
+        }
+
+        var cor = pe.PEHeaders.CorHeader;
+        if (cor == null)
+        {
+            return false;
+        }
+
+        // Pure IL assemblies are platform-portable.
+        if ((cor.Flags & CorFlags.ILOnly) != 0)
+        {
+            return true;
+        }
+
+        // Native code present. The bundle's native code is Windows-targeting; require
+        // both an OS match and a Machine match.
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return false;
+        }
+
+        return MachineMatchesCurrentArchitecture(pe.PEHeaders.CoffHeader.Machine);
+    }
+
+    private static bool MachineMatchesCurrentArchitecture(Machine peMachine)
+        => RuntimeInformation.ProcessArchitecture switch
+        {
+            Architecture.X64 => peMachine == Machine.Amd64,
+            Architecture.X86 => peMachine == Machine.I386,
+            Architecture.Arm64 => peMachine == Machine.Arm64,
+            Architecture.Arm => peMachine == Machine.Arm,
+            _ => false
+        };
+
+    private static string? GetBundledAnalyzersDirectory()
+    {
+        // Microsoft.CodeAnalysis.dll lives at:
+        //   .NET Core:      tasks/net8.0/bincore/Microsoft.CodeAnalysis.dll
+        //   .NET Framework: tasks/net472/Microsoft.CodeAnalysis.dll
+        // sdkAnalyzers/ is a sibling of tasks/, so walk up 3 levels for bincore,
+        // 2 levels otherwise.
+        var assemblyDirectory = Path.GetDirectoryName(typeof(AnalyzerAssemblyRedirector).Assembly.Location);
+        if (string.IsNullOrEmpty(assemblyDirectory))
+        {
+            return null;
+        }
+
+        var pathToRoot = assemblyDirectory!.Contains("bincore") ? "../../.." : "../..";
+        var dir = FileUtilities.TryNormalizeAbsolutePath(Path.Combine(assemblyDirectory, pathToRoot, "sdkAnalyzers"))
+                  ?? Path.GetFullPath(Path.Combine(assemblyDirectory, pathToRoot, "sdkAnalyzers"));
+
+        return Directory.Exists(dir) ? dir : null;
+    }
+
+    private static string? GetBundledSdkVersion()
+        => typeof(AnalyzerAssemblyRedirector).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(a => a.Key == "DotnetSdkVersion")?.Value;
+
     /// <summary>
     /// Returns a previously-cached redirect path for the given analyzer file (typically
     /// pre-populated as a sibling of a previously-redirected analyzer). Does not trigger
@@ -256,6 +364,24 @@ internal static class AnalyzerAssemblyRedirector
     /// <summary>Snapshot of installed SDK versions for inclusion in the no-found error.</summary>
     public static IReadOnlyList<Version> EnumerateInstalledSdkVersions()
         => DotNetInstallationLocator.Sdks.Select(s => s.Version).ToArray();
+
+    /// <summary>
+    /// Returns the SDK version that <paramref name="redirectedPath"/> belongs to. For a
+    /// path inside the bundle, returns the version embedded in Microsoft.CodeAnalysis.dll
+    /// at build time (<c>DotnetSdkVersion</c>). For a path inside an installed SDK, parses
+    /// the version from the <c>/sdk/&lt;version&gt;/</c> segment. Returns null when neither
+    /// is applicable.
+    /// </summary>
+    public static string? GetRedirectedAnalyzerSdkVersion(string redirectedPath)
+    {
+        if (s_bundledAnalyzersDirectory.Value is { } bundle
+            && redirectedPath.StartsWith(bundle, StringComparison.OrdinalIgnoreCase))
+        {
+            return s_bundledSdkVersion.Value;
+        }
+
+        return TryExtractSdkVersionFromPath(redirectedPath);
+    }
 
     /// <summary>
     /// Extracts the SDK version from a path like

--- a/src/Metalama/tests/docker/DockerTests.ps1
+++ b/src/Metalama/tests/docker/DockerTests.ps1
@@ -136,9 +136,9 @@ foreach ($s in $scenarios) {
 
         # Discover the Metalama.Compiler version that the local-feed contains, then substitute
         # any $LOCAL_COMPILER_VERSION$ placeholder in the staged scenario sources. Scenarios
-        # should reference Metalama.Compiler at this exact version via PackageReference
-        # VersionOverride, otherwise NuGet picks up the (older) transitive version from
-        # Metalama.Framework.
+        # define $(MetalamaCompilerVersion) in their Directory.Build.props from this placeholder
+        # and reference Metalama.Compiler at $(MetalamaCompilerVersion) — Metalama.Compiler is
+        # upstream of Metalama.Framework, so test projects never reference the latter.
         # Sort by LastWriteTime desc so that when the local feed contains multiple builds
         # of Metalama.Compiler (a common case for repeated local-dev runs) we pick the
         # one most recently produced instead of a filesystem-enumeration-order winner.

--- a/src/Metalama/tests/docker/DockerTests.ps1
+++ b/src/Metalama/tests/docker/DockerTests.ps1
@@ -142,9 +142,11 @@ foreach ($s in $scenarios) {
         # Sort by LastWriteTime desc so that when the local feed contains multiple builds
         # of Metalama.Compiler (a common case for repeated local-dev runs) we pick the
         # one most recently produced instead of a filesystem-enumeration-order winner.
+        # Match only `Metalama.Compiler.<version>.nupkg` where <version> starts with a
+        # digit. This excludes sibling packages whose ID starts with "Metalama.Compiler."
+        # (Sdk, Arm64, or any hypothetical future siblings).
         $compilerNupkg = Get-ChildItem $stagedFeed -Filter 'Metalama.Compiler.*.nupkg' |
-            Where-Object Name -notlike 'Metalama.Compiler.Sdk.*' |
-            Where-Object Name -notlike 'Metalama.Compiler.Arm64.*' |
+            Where-Object { $_.Name -match '^Metalama\.Compiler\.\d' } |
             Sort-Object LastWriteTime -Descending |
             Select-Object -First 1
         if (-not $compilerNupkg) {

--- a/src/Metalama/tests/docker/linux-x64/BlazorRazor-NoLkgSdk/src/BlazorRazor.csproj
+++ b/src/Metalama/tests/docker/linux-x64/BlazorRazor-NoLkgSdk/src/BlazorRazor.csproj
@@ -4,20 +4,11 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <!-- The locally-built Metalama.Compiler has a prerelease version like "2026.0.12-local-...";
-         NuGet would otherwise treat it as a "downgrade" from Metalama.Framework's transitive 2026.0.12. -->
-    <NoWarn>$(NoWarn);NU1605</NoWarn>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.0" />
-    <PackageReference Include="Metalama.Framework" Version="2026.0.22" />
-    <!--
-      VersionOverride forces NuGet to use our locally-built Metalama.Compiler instead
-      of the transitive 2026.0.12 that Metalama.Framework 2026.0.22 brings in.
-    -->
-    <PackageReference Include="Metalama.Compiler" VersionOverride="$LOCAL_COMPILER_VERSION$" />
+    <PackageReference Include="Metalama.Compiler" Version="$(MetalamaCompilerVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Metalama/tests/docker/linux-x64/BlazorRazor-NoLkgSdk/src/Directory.Build.props
+++ b/src/Metalama/tests/docker/linux-x64/BlazorRazor-NoLkgSdk/src/Directory.Build.props
@@ -1,3 +1,8 @@
 <Project>
   <!-- Isolated from the rest of the Metalama.Compiler repo. -->
+  <PropertyGroup>
+    <!-- DockerTests.ps1 substitutes this placeholder with the locally-built
+         Metalama.Compiler nupkg version found in /local-feed. -->
+    <MetalamaCompilerVersion>$LOCAL_COMPILER_VERSION$</MetalamaCompilerVersion>
+  </PropertyGroup>
 </Project>

--- a/src/Metalama/tests/docker/linux-x64/BlazorRazor/src/BlazorRazor.csproj
+++ b/src/Metalama/tests/docker/linux-x64/BlazorRazor/src/BlazorRazor.csproj
@@ -4,20 +4,11 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <!-- The locally-built Metalama.Compiler has a prerelease version like "2026.0.12-local-...";
-         NuGet would otherwise treat it as a "downgrade" from Metalama.Framework's transitive 2026.0.12. -->
-    <NoWarn>$(NoWarn);NU1605</NoWarn>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.0" />
-    <PackageReference Include="Metalama.Framework" Version="2026.0.22" />
-    <!--
-      VersionOverride forces NuGet to use our locally-built Metalama.Compiler instead
-      of the transitive 2026.0.12 that Metalama.Framework 2026.0.22 brings in.
-    -->
-    <PackageReference Include="Metalama.Compiler" VersionOverride="$LOCAL_COMPILER_VERSION$" />
+    <PackageReference Include="Metalama.Compiler" Version="$(MetalamaCompilerVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Metalama/tests/docker/linux-x64/BlazorRazor/src/Directory.Build.props
+++ b/src/Metalama/tests/docker/linux-x64/BlazorRazor/src/Directory.Build.props
@@ -1,3 +1,8 @@
 <Project>
   <!-- Isolated from the rest of the Metalama.Compiler repo. -->
+  <PropertyGroup>
+    <!-- DockerTests.ps1 substitutes this placeholder with the locally-built
+         Metalama.Compiler nupkg version found in /local-feed. -->
+    <MetalamaCompilerVersion>$LOCAL_COMPILER_VERSION$</MetalamaCompilerVersion>
+  </PropertyGroup>
 </Project>

--- a/src/Metalama/tests/docker/linux-x64/Issue180Repro/src/BlazorRepro.csproj
+++ b/src/Metalama/tests/docker/linux-x64/Issue180Repro/src/BlazorRepro.csproj
@@ -4,14 +4,14 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <!-- Treat all warnings as errors so the LAMA0617 / CS8034 diagnostics surface as build failures. -->
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.0" />
-    <!-- Pulls Metalama.Compiler 2026.0.12 (the one shipping the Windows-R2R sdkAnalyzers/Microsoft.CodeAnalysis.Razor.Compiler.dll). -->
-    <PackageReference Include="Metalama.Framework" Version="2026.0.22" />
+    <!-- Published 2026.0.12 ships the Windows-R2R sdkAnalyzers/Microsoft.CodeAnalysis.Razor.Compiler.dll
+         that fails to load on Linux (issue #180). This scenario asserts that loading failure shows up
+         in the build log, demonstrating the bug as published. -->
+    <PackageReference Include="Metalama.Compiler" Version="2026.0.12" />
   </ItemGroup>
 
 </Project>

--- a/src/Metalama/tests/docker/linux-x64/LoggerMessage/src/Directory.Build.props
+++ b/src/Metalama/tests/docker/linux-x64/LoggerMessage/src/Directory.Build.props
@@ -1,2 +1,7 @@
 <Project>
+  <PropertyGroup>
+    <!-- DockerTests.ps1 substitutes this placeholder with the locally-built
+         Metalama.Compiler nupkg version found in /local-feed. -->
+    <MetalamaCompilerVersion>$LOCAL_COMPILER_VERSION$</MetalamaCompilerVersion>
+  </PropertyGroup>
 </Project>

--- a/src/Metalama/tests/docker/linux-x64/LoggerMessage/src/LoggerMessage.csproj
+++ b/src/Metalama/tests/docker/linux-x64/LoggerMessage/src/LoggerMessage.csproj
@@ -5,17 +5,12 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <!-- The locally-built Metalama.Compiler has a prerelease version; NuGet would otherwise
-         treat it as a "downgrade" from Metalama.Framework's transitive 2026.0.12. -->
-    <NoWarn>$(NoWarn);NU1605</NoWarn>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
-    <PackageReference Include="Metalama.Framework" Version="2026.0.22" />
-    <PackageReference Include="Metalama.Compiler" VersionOverride="$LOCAL_COMPILER_VERSION$" />
+    <PackageReference Include="Metalama.Compiler" Version="$(MetalamaCompilerVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Metalama/tests/docker/win-x64/BlazorRazor-BundleMissing/Dockerfile
+++ b/src/Metalama/tests/docker/win-x64/BlazorRazor-BundleMissing/Dockerfile
@@ -1,21 +1,21 @@
 # escape=`
 FROM mcr.microsoft.com/windows/servercore:ltsc2025
 
-# Hybrid-bundle Windows scenario: install ONLY the primary SDK, no LKG side-by-side.
-# This is the core Windows promise of the hybrid approach — even when the only SDK
-# on the host carries analyzers that reference a Roslyn newer than ours (because
-# e.g. VS Update replaced the previous SDK), the bundled sdkAnalyzers/ folder in
-# Metalama.Compiler's nupkg supplies a compatible older copy that the net472 csc
-# loads directly. .NET Framework targeting comes via the
-# Microsoft.NETFramework.ReferenceAssemblies.net48 NuGet, no .NET Framework SDK
-# image needed.
+# Hybrid-fallback Windows scenario: install BOTH the primary SDK (whose Razor
+# analyzers are too new for our Roslyn) AND a compatible LKG SDK. Then strip
+# the sdkAnalyzers/ bundle out of the local-feed Metalama.Compiler nupkg before
+# project build. Validates the Windows fallback-backstop: when the bundle is
+# absent for any reason, the installed-SDK scan finds the LKG and the build
+# succeeds with a LAMA0617 warning instead of a LAMA0625 error.
 ARG DOTNET_PRIMARY=10.0.300
+ARG DOTNET_LKG=10.0.203
 
 SHELL ["powershell", "-NoProfile", "-Command"]
 
 RUN $ErrorActionPreference = 'Stop'; `
     Invoke-WebRequest -Uri https://dot.net/v1/dotnet-install.ps1 -OutFile dotnet-install.ps1; `
     & .\dotnet-install.ps1 -Version $env:DOTNET_PRIMARY -InstallDir 'C:\Program Files\dotnet'; `
+    & .\dotnet-install.ps1 -Version $env:DOTNET_LKG -InstallDir 'C:\Program Files\dotnet'; `
     Remove-Item dotnet-install.ps1
 
 ENV PATH="C:\Program Files\dotnet;${PATH}"
@@ -27,7 +27,5 @@ COPY src/ C:/app/
 COPY local-feed/ C:/local-feed/
 COPY test.ps1 C:/app/test.ps1
 
-# Reset SHELL so the ENTRYPOINT exec-form below isn't wrapped by the docker CMD shell.
-# Use full path to powershell.exe — exec-form doesn't go through PATH resolution.
 SHELL ["cmd", "/S", "/C"]
 ENTRYPOINT ["C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", "-NoProfile", "-File", "C:\\app\\test.ps1"]

--- a/src/Metalama/tests/docker/win-x64/BlazorRazor-BundleMissing/src/BlazorRazor.csproj
+++ b/src/Metalama/tests/docker/win-x64/BlazorRazor-BundleMissing/src/BlazorRazor.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <NoWarn>$(NoWarn);NU1605</NoWarn>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.0" />
+    <PackageReference Include="Metalama.Framework" Version="2026.0.22" />
+    <PackageReference Include="Metalama.Compiler" VersionOverride="$LOCAL_COMPILER_VERSION$" />
+  </ItemGroup>
+
+</Project>

--- a/src/Metalama/tests/docker/win-x64/BlazorRazor-BundleMissing/src/BlazorRazor.csproj
+++ b/src/Metalama/tests/docker/win-x64/BlazorRazor-BundleMissing/src/BlazorRazor.csproj
@@ -4,14 +4,11 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <NoWarn>$(NoWarn);NU1605</NoWarn>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.0" />
-    <PackageReference Include="Metalama.Framework" Version="2026.0.22" />
-    <PackageReference Include="Metalama.Compiler" VersionOverride="$LOCAL_COMPILER_VERSION$" />
+    <PackageReference Include="Metalama.Compiler" Version="$(MetalamaCompilerVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Metalama/tests/docker/win-x64/BlazorRazor-BundleMissing/src/Component1.razor
+++ b/src/Metalama/tests/docker/win-x64/BlazorRazor-BundleMissing/src/Component1.razor
@@ -1,0 +1,11 @@
+<h3>Component1</h3>
+
+<p>Current count: @currentCount</p>
+
+<button @onclick="Increment">Click me</button>
+
+@code {
+    private int currentCount = 0;
+
+    private void Increment() => currentCount++;
+}

--- a/src/Metalama/tests/docker/win-x64/BlazorRazor-BundleMissing/src/Directory.Build.props
+++ b/src/Metalama/tests/docker/win-x64/BlazorRazor-BundleMissing/src/Directory.Build.props
@@ -1,0 +1,3 @@
+<Project>
+  <!-- Isolated from the rest of the Metalama.Compiler repo. -->
+</Project>

--- a/src/Metalama/tests/docker/win-x64/BlazorRazor-BundleMissing/src/Directory.Build.props
+++ b/src/Metalama/tests/docker/win-x64/BlazorRazor-BundleMissing/src/Directory.Build.props
@@ -1,3 +1,8 @@
 <Project>
   <!-- Isolated from the rest of the Metalama.Compiler repo. -->
+  <PropertyGroup>
+    <!-- DockerTests.ps1 substitutes this placeholder with the locally-built
+         Metalama.Compiler nupkg version found in C:/local-feed. -->
+    <MetalamaCompilerVersion>$LOCAL_COMPILER_VERSION$</MetalamaCompilerVersion>
+  </PropertyGroup>
 </Project>

--- a/src/Metalama/tests/docker/win-x64/BlazorRazor-BundleMissing/src/Directory.Build.targets
+++ b/src/Metalama/tests/docker/win-x64/BlazorRazor-BundleMissing/src/Directory.Build.targets
@@ -1,0 +1,2 @@
+<Project>
+</Project>

--- a/src/Metalama/tests/docker/win-x64/BlazorRazor-BundleMissing/src/NuGet.config
+++ b/src/Metalama/tests/docker/win-x64/BlazorRazor-BundleMissing/src/NuGet.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="local-feed" value="C:/local-feed" />
+  </packageSources>
+</configuration>

--- a/src/Metalama/tests/docker/win-x64/BlazorRazor-BundleMissing/src/_Imports.razor
+++ b/src/Metalama/tests/docker/win-x64/BlazorRazor-BundleMissing/src/_Imports.razor
@@ -1,0 +1,2 @@
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web

--- a/src/Metalama/tests/docker/win-x64/BlazorRazor-BundleMissing/src/global.json
+++ b/src/Metalama/tests/docker/win-x64/BlazorRazor-BundleMissing/src/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.300",
+    "rollForward": "latestPatch"
+  }
+}

--- a/src/Metalama/tests/docker/win-x64/BlazorRazor-BundleMissing/test.ps1
+++ b/src/Metalama/tests/docker/win-x64/BlazorRazor-BundleMissing/test.ps1
@@ -1,0 +1,53 @@
+$ErrorActionPreference = 'Stop'
+Set-Location C:\app
+
+# Strip sdkAnalyzers/ from the local-feed Metalama.Compiler nupkg before NuGet
+# touches it. The nupkg is a ZIP; we delete entries under sdkAnalyzers/ via
+# System.IO.Compression then save back in-place.
+Write-Host '--- stripping sdkAnalyzers/ from local-feed Metalama.Compiler nupkg ---'
+$compilerNupkg = Get-ChildItem 'C:\local-feed' -Filter 'Metalama.Compiler.*.nupkg' |
+    Where-Object Name -notlike 'Metalama.Compiler.Sdk.*' |
+    Where-Object Name -notlike 'Metalama.Compiler.Arm64.*' |
+    Sort-Object LastWriteTime -Descending |
+    Select-Object -First 1
+if (-not $compilerNupkg) { throw 'no Metalama.Compiler nupkg found in /local-feed' }
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+$zip = [System.IO.Compression.ZipFile]::Open($compilerNupkg.FullName, 'Update')
+try {
+    $entries = @($zip.Entries | Where-Object { $_.FullName -like 'sdkAnalyzers/*' })
+    foreach ($e in $entries) {
+        Write-Host "  remove $($e.FullName)"
+        $e.Delete()
+    }
+    Write-Host "Stripped $($entries.Count) entries from $($compilerNupkg.Name)"
+} finally {
+    $zip.Dispose()
+}
+
+dotnet --info
+Write-Host '--- restore ---'
+dotnet restore BlazorRazor.csproj
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+Write-Host '--- build ---'
+dotnet build BlazorRazor.csproj --no-restore -c Debug 2>&1 | Tee-Object -FilePath build.log
+$buildRc = $LASTEXITCODE
+
+if ($buildRc -ne 0) {
+    Write-Host "BUILD FAILED (rc=$buildRc) - the installed-SDK fallback should have rescued the build"
+    exit $buildRc
+}
+if (Select-String -Path build.log -Pattern 'BadImageFormatException' -Quiet) {
+    Write-Host 'FAIL: BadImageFormatException'
+    exit 1
+}
+if (Select-String -Path build.log -Pattern 'error LAMA0625' -Quiet) {
+    Write-Host 'FAIL: LAMA0625 - fallback should have found the LKG SDK'
+    exit 1
+}
+if (-not (Select-String -Path build.log -Pattern 'warning LAMA0617' -Quiet)) {
+    Write-Host 'FAIL: expected LAMA0617 (fallback redirect) but none found'
+    exit 1
+}
+
+Write-Host 'OK: win-x64/BlazorRazor-BundleMissing scenario passed'

--- a/src/Metalama/tests/docker/win-x64/BlazorRazor-BundleMissing/test.ps1
+++ b/src/Metalama/tests/docker/win-x64/BlazorRazor-BundleMissing/test.ps1
@@ -5,9 +5,11 @@ Set-Location C:\app
 # touches it. The nupkg is a ZIP; we delete entries under sdkAnalyzers/ via
 # System.IO.Compression then save back in-place.
 Write-Host '--- stripping sdkAnalyzers/ from local-feed Metalama.Compiler nupkg ---'
+# Match only `Metalama.Compiler.<version>.nupkg` where <version> starts with a digit.
+# This excludes sibling packages whose ID starts with "Metalama.Compiler." (e.g.
+# Metalama.Compiler.Sdk, Metalama.Compiler.Arm64, or hypothetical Common/etc.).
 $compilerNupkg = Get-ChildItem 'C:\local-feed' -Filter 'Metalama.Compiler.*.nupkg' |
-    Where-Object Name -notlike 'Metalama.Compiler.Sdk.*' |
-    Where-Object Name -notlike 'Metalama.Compiler.Arm64.*' |
+    Where-Object { $_.Name -match '^Metalama\.Compiler\.\d' } |
     Sort-Object LastWriteTime -Descending |
     Select-Object -First 1
 if (-not $compilerNupkg) { throw 'no Metalama.Compiler nupkg found in /local-feed' }

--- a/src/Metalama/tests/docker/win-x64/BlazorRazor/Dockerfile
+++ b/src/Metalama/tests/docker/win-x64/BlazorRazor/Dockerfile
@@ -1,14 +1,12 @@
 # escape=`
 FROM mcr.microsoft.com/windows/servercore:ltsc2025
 
-# Hybrid-bundle Windows scenario: install ONLY the primary SDK, no LKG side-by-side.
-# This is the core Windows promise of the hybrid approach — even when the only SDK
-# on the host carries analyzers that reference a Roslyn newer than ours (because
-# e.g. VS Update replaced the previous SDK), the bundled sdkAnalyzers/ folder in
-# Metalama.Compiler's nupkg supplies a compatible older copy that the net472 csc
-# loads directly. .NET Framework targeting comes via the
-# Microsoft.NETFramework.ReferenceAssemblies.net48 NuGet, no .NET Framework SDK
-# image needed.
+# Hybrid-bundle Windows scenario: install ONLY the primary SDK. SDK 10.0.300 ships
+# Razor analyzers built for Roslyn 5.5 (newer than Metalama Compiler's bundled
+# Roslyn 5.3) → triggers the redirect. With no compatible LKG SDK installed, the
+# only way the build can succeed is via the bundled sdkAnalyzers/ folder shipped
+# inside the Metalama.Compiler nupkg. This validates the Windows promise: the
+# bundle keeps customers green even when their only installed SDK is too new.
 ARG DOTNET_PRIMARY=10.0.300
 
 SHELL ["powershell", "-NoProfile", "-Command"]
@@ -27,7 +25,5 @@ COPY src/ C:/app/
 COPY local-feed/ C:/local-feed/
 COPY test.ps1 C:/app/test.ps1
 
-# Reset SHELL so the ENTRYPOINT exec-form below isn't wrapped by the docker CMD shell.
-# Use full path to powershell.exe — exec-form doesn't go through PATH resolution.
 SHELL ["cmd", "/S", "/C"]
 ENTRYPOINT ["C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", "-NoProfile", "-File", "C:\\app\\test.ps1"]

--- a/src/Metalama/tests/docker/win-x64/BlazorRazor/src/BlazorRazor.csproj
+++ b/src/Metalama/tests/docker/win-x64/BlazorRazor/src/BlazorRazor.csproj
@@ -4,20 +4,11 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <!-- The locally-built Metalama.Compiler has a prerelease version like "2026.0.12-local-...";
-         NuGet would otherwise treat it as a "downgrade" from Metalama.Framework's transitive 2026.0.12. -->
-    <NoWarn>$(NoWarn);NU1605</NoWarn>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.0" />
-    <PackageReference Include="Metalama.Framework" Version="2026.0.22" />
-    <!--
-      VersionOverride forces NuGet to use our locally-built Metalama.Compiler instead
-      of the transitive 2026.0.12 that Metalama.Framework 2026.0.22 brings in.
-    -->
-    <PackageReference Include="Metalama.Compiler" VersionOverride="$LOCAL_COMPILER_VERSION$" />
+    <PackageReference Include="Metalama.Compiler" Version="$(MetalamaCompilerVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Metalama/tests/docker/win-x64/BlazorRazor/src/BlazorRazor.csproj
+++ b/src/Metalama/tests/docker/win-x64/BlazorRazor/src/BlazorRazor.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- The locally-built Metalama.Compiler has a prerelease version like "2026.0.12-local-...";
+         NuGet would otherwise treat it as a "downgrade" from Metalama.Framework's transitive 2026.0.12. -->
+    <NoWarn>$(NoWarn);NU1605</NoWarn>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.0" />
+    <PackageReference Include="Metalama.Framework" Version="2026.0.22" />
+    <!--
+      VersionOverride forces NuGet to use our locally-built Metalama.Compiler instead
+      of the transitive 2026.0.12 that Metalama.Framework 2026.0.22 brings in.
+    -->
+    <PackageReference Include="Metalama.Compiler" VersionOverride="$LOCAL_COMPILER_VERSION$" />
+  </ItemGroup>
+
+</Project>

--- a/src/Metalama/tests/docker/win-x64/BlazorRazor/src/Component1.razor
+++ b/src/Metalama/tests/docker/win-x64/BlazorRazor/src/Component1.razor
@@ -1,0 +1,11 @@
+<h3>Component1</h3>
+
+<p>Current count: @currentCount</p>
+
+<button @onclick="Increment">Click me</button>
+
+@code {
+    private int currentCount = 0;
+
+    private void Increment() => currentCount++;
+}

--- a/src/Metalama/tests/docker/win-x64/BlazorRazor/src/Directory.Build.props
+++ b/src/Metalama/tests/docker/win-x64/BlazorRazor/src/Directory.Build.props
@@ -1,0 +1,3 @@
+<Project>
+  <!-- Isolated from the rest of the Metalama.Compiler repo. -->
+</Project>

--- a/src/Metalama/tests/docker/win-x64/BlazorRazor/src/Directory.Build.props
+++ b/src/Metalama/tests/docker/win-x64/BlazorRazor/src/Directory.Build.props
@@ -1,3 +1,8 @@
 <Project>
   <!-- Isolated from the rest of the Metalama.Compiler repo. -->
+  <PropertyGroup>
+    <!-- DockerTests.ps1 substitutes this placeholder with the locally-built
+         Metalama.Compiler nupkg version found in C:/local-feed. -->
+    <MetalamaCompilerVersion>$LOCAL_COMPILER_VERSION$</MetalamaCompilerVersion>
+  </PropertyGroup>
 </Project>

--- a/src/Metalama/tests/docker/win-x64/BlazorRazor/src/Directory.Build.targets
+++ b/src/Metalama/tests/docker/win-x64/BlazorRazor/src/Directory.Build.targets
@@ -1,0 +1,2 @@
+<Project>
+</Project>

--- a/src/Metalama/tests/docker/win-x64/BlazorRazor/src/NuGet.config
+++ b/src/Metalama/tests/docker/win-x64/BlazorRazor/src/NuGet.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <!-- DockerTests.ps1 stages the locally-built Metalama.Compiler nupkgs into C:/local-feed -->
+    <add key="local-feed" value="C:/local-feed" />
+  </packageSources>
+</configuration>

--- a/src/Metalama/tests/docker/win-x64/BlazorRazor/src/_Imports.razor
+++ b/src/Metalama/tests/docker/win-x64/BlazorRazor/src/_Imports.razor
@@ -1,0 +1,2 @@
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web

--- a/src/Metalama/tests/docker/win-x64/BlazorRazor/src/global.json
+++ b/src/Metalama/tests/docker/win-x64/BlazorRazor/src/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.300",
+    "rollForward": "latestPatch"
+  }
+}

--- a/src/Metalama/tests/docker/win-x64/BlazorRazor/test.ps1
+++ b/src/Metalama/tests/docker/win-x64/BlazorRazor/test.ps1
@@ -27,7 +27,12 @@ if (Select-String -Path build.log -Pattern 'error LAMA0625' -Quiet) {
     exit 1
 }
 if (-not (Select-String -Path build.log -Pattern 'warning LAMA0617' -Quiet)) {
-    Write-Host 'WARN: expected LAMA0617 redirect notice but none found'
+    # Both bundle hit and installed-SDK hit emit LAMA0617. Its absence means the
+    # redirect never fired and the build only passed by accident (e.g. the analyzer
+    # was already binary-compatible). Hard fail so the scenario actually proves the
+    # bundle path is in use.
+    Write-Host 'FAIL: expected LAMA0617 redirect notice but none found - redirect did not fire'
+    exit 1
 }
 
 Write-Host 'OK: win-x64/BlazorRazor scenario passed'

--- a/src/Metalama/tests/docker/win-x64/BlazorRazor/test.ps1
+++ b/src/Metalama/tests/docker/win-x64/BlazorRazor/test.ps1
@@ -1,0 +1,33 @@
+$ErrorActionPreference = 'Stop'
+Set-Location C:\app
+
+dotnet --info
+Write-Host '--- restore ---'
+dotnet restore BlazorRazor.csproj
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+Write-Host '--- build ---'
+dotnet build BlazorRazor.csproj --no-restore -c Debug 2>&1 | Tee-Object -FilePath build.log
+$buildRc = $LASTEXITCODE
+
+if ($buildRc -ne 0) {
+    Write-Host "BUILD FAILED (rc=$buildRc)"
+    exit $buildRc
+}
+if (Select-String -Path build.log -Pattern 'BadImageFormatException' -Quiet) {
+    Write-Host 'FAIL: BadImageFormatException'
+    exit 1
+}
+if (Select-String -Path build.log -Pattern 'warning CS8034' -Quiet) {
+    Write-Host 'FAIL: CS8034 analyzer load failure'
+    exit 1
+}
+if (Select-String -Path build.log -Pattern 'error LAMA0625' -Quiet) {
+    Write-Host 'FAIL: LAMA0625 ERR_NoCompatibleSdkForAnalyzer (the bundle should have covered this)'
+    exit 1
+}
+if (-not (Select-String -Path build.log -Pattern 'warning LAMA0617' -Quiet)) {
+    Write-Host 'WARN: expected LAMA0617 redirect notice but none found'
+}
+
+Write-Host 'OK: win-x64/BlazorRazor scenario passed'

--- a/src/Metalama/tests/docker/win-x64/Net48LoggerMessage/src/Directory.Build.props
+++ b/src/Metalama/tests/docker/win-x64/Net48LoggerMessage/src/Directory.Build.props
@@ -1,2 +1,7 @@
 <Project>
+  <PropertyGroup>
+    <!-- DockerTests.ps1 substitutes this placeholder with the locally-built
+         Metalama.Compiler nupkg version found in C:/local-feed. -->
+    <MetalamaCompilerVersion>$LOCAL_COMPILER_VERSION$</MetalamaCompilerVersion>
+  </PropertyGroup>
 </Project>

--- a/src/Metalama/tests/docker/win-x64/Net48LoggerMessage/src/Net48LoggerMessage.csproj
+++ b/src/Metalama/tests/docker/win-x64/Net48LoggerMessage/src/Net48LoggerMessage.csproj
@@ -3,13 +3,11 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net48</TargetFramework>
+    <!-- net48 defaults to C# 7.3 which doesn't allow Nullable/ImplicitUsings. -->
+    <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Net48LoggerMessage</RootNamespace>
-    <!-- The locally-built Metalama.Compiler has a prerelease version; NuGet would otherwise
-         treat it as a "downgrade" from Metalama.Framework's transitive 2026.0.12. -->
-    <NoWarn>$(NoWarn);NU1605</NoWarn>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,8 +15,7 @@
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageReference Include="Metalama.Framework" Version="2026.0.22" />
-    <PackageReference Include="Metalama.Compiler" VersionOverride="$LOCAL_COMPILER_VERSION$" />
+    <PackageReference Include="Metalama.Compiler" Version="$(MetalamaCompilerVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/AnyCpu/Metalama.Compiler.Package.csproj
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/AnyCpu/Metalama.Compiler.Package.csproj
@@ -67,6 +67,9 @@
 
   <Target Name="_GetFilesToPackage" DependsOnTargets="$(_DependsOn)">
     <!-- <Metalama> -->
+    <Exec Command="dotnet run $(RoslynVersion)" WorkingDirectory="..\..\..\..\eng-Metalama\DownloadNetSdkAnalyzers" ConsoleToMsBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="NetSdkAnalyzersPath" />
+    </Exec>
     <ItemGroup>
       <_File Include="@(DesktopCompilerArtifact)" TargetDir="tasks/net472"/>
       <_File Include="@(DesktopCompilerResourceArtifact)" TargetDir="tasks/net472"/>
@@ -82,6 +85,7 @@
       <_File Include="@(DesktopMetalamaCompilerBinArtifact)" TargetDir="tasks/net472" Condition="'$(TargetFramework)' == 'net472'" />
       <_File Include="@(CommonMetalamaCompilerBinArtifact)" TargetDir="tasks/$(TargetFramework)/bincore" Condition="'$(TargetFramework)' != 'net472'" />
       <_File Include="@(CoreClrMetalamaCompilerBinArtifact)" TargetDir="tasks/$(TargetFramework)/bincore" Condition="'$(TargetFramework)' != 'net472'" />
+      <_File Include="$(NetSdkAnalyzersPath)\*.dll" TargetDir="sdkAnalyzers" />
 
       <TfmSpecificPackageFile Include="@(_File)" PackagePath="%(_File.TargetDir)/%(_File.RecursiveDir)%(_File.FileName)%(_File.Extension)" />
     </ItemGroup>


### PR DESCRIPTION
## Summary

- Restores Metalama.Compiler''s pre-PR-#181 mechanism of bundling Windows-x64 SDK analyzer DLLs in the package''s `sdkAnalyzers/` folder. On Windows hosts this keeps Metalama building even when the only installed .NET SDK has been replaced by a VS update with one whose analyzers reference a Roslyn newer than ours.
- Keeps the installed-SDK runtime fallback introduced by #181 for Linux/macOS (where the Windows-x64 R2R bundle isn''t loadable) and as a Windows-side backstop when the bundle is missing.
- New PE-inspection-based loadability check decides per-file whether to use the bundle or fall through - pure-IL DLLs are accepted everywhere; native-code DLLs require both OS match (Windows) and `COFF.Machine == ProcessArchitecture`.

## Design

`AnalyzerAssemblyRedirector.FindCompatibleAnalyzer` resolution order:

1. `TryGetBundledRedirect(fileName)` - bundle path + loadability check. Hit if PE inspection says the bundle DLL is loadable here.
2. `FindUncached(...)` - installed-SDK scan (unchanged from #181).
3. null - caller emits `LAMA0625 ERR_NoCompatibleSdkForAnalyzer`.

Both bundle hits and SDK-scan hits emit `LAMA0617 WRN_AnalyzerAssembliesRedirected`. `GetRedirectedAnalyzerSdkVersion` returns the bundle''s `DotnetSdkVersion` AssemblyMetadata attribute for bundle paths, and `TryExtractSdkVersionFromPath` for SDK paths.

## Test plan changes

Linux scenarios untouched (still validate the runtime fallback).

- **`win-x64/Net48LoggerMessage`** (modified) - dropped the LKG SDK install. Validates that the bundle alone makes the build succeed via the net472 csc task host, with no compatible SDK installed.
- **`win-x64/BlazorRazor`** (new) - same shape on .NET 10 csc.
- **`win-x64/BlazorRazor-BundleMissing`** (new) - both SDKs installed, bundle stripped from the local-feed nupkg before build. Validates the Windows fallback-backstop: the installed-SDK scan rescues the build with a `LAMA0617` instead of a `LAMA0625`.

## Issues fixed

Follow-up to PR #181 which addressed [#180](https://github.com/metalama/Metalama.Compiler/issues/180). The original fix relied solely on installed SDKs on the build host; this PR adds the Windows bundle back as the primary path so VS-update-induced SDK churn on Windows hosts no longer breaks Metalama builds.