### PR TITLE
Fix MSB4175 when MSBuildToolsPath contains parentheses (metalama/Metalama#1699)

### DIFF
--- a/src/Metalama/tests/docker/win-x64/Issue1699X86Sdk/Dockerfile
+++ b/src/Metalama/tests/docker/win-x64/Issue1699X86Sdk/Dockerfile
@@ -1,0 +1,39 @@
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:ltsc2025
+
+# Regression test for Metalama.Compiler issue #1699.
+#
+# Metalama.Compiler.targets declares a RoslynCodeTaskFactory UsingTask whose
+# AssemblyFile is computed with a property function ($([System.IO.Path]::Combine(...)))
+# over $(MSBuildToolsPath). Property functions escape the MSBuild-special chars
+# '(' and ')' to '%28'/'%29', and a TaskFactory's AssemblyFile is consumed WITHOUT
+# unescaping. So when the tools path contains parentheses the literal
+# 'Program Files %28x86%29' reaches assembly loading and the build fails with
+# MSB4175 ("could not be loaded from the assembly ...").
+#
+# The customer hit this via VS Build Tools MSBuild under 'C:\Program Files (x86)'.
+# The simplest deterministic reproduction is the x86 .NET SDK, which installs
+# under 'C:\Program Files (x86)\dotnet', so a plain 'dotnet build' sees a
+# paren-containing $(MSBuildToolsPath).
+ARG DOTNET_PRIMARY=10.0.301
+
+SHELL ["powershell", "-NoProfile", "-Command"]
+
+# Install the x86 SDK into the parenthesised Program Files (x86) path on purpose.
+RUN $ErrorActionPreference = 'Stop'; `
+    Invoke-WebRequest -Uri https://dot.net/v1/dotnet-install.ps1 -OutFile dotnet-install.ps1; `
+    & .\dotnet-install.ps1 -Version $env:DOTNET_PRIMARY -Architecture x86 -InstallDir 'C:\Program Files (x86)\dotnet'; `
+    Remove-Item dotnet-install.ps1
+
+ENV PATH="C:\Program Files (x86)\dotnet;${PATH}"
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_NOLOGO=1
+ENV DOTNET_ROLL_FORWARD=latestMajor
+
+WORKDIR C:/app
+COPY src/ C:/app/
+COPY local-feed/ C:/local-feed/
+COPY test.ps1 C:/app/test.ps1
+
+SHELL ["cmd", "/S", "/C"]
+ENTRYPOINT ["C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", "-NoProfile", "-File", "C:\\app\\test.ps1"]

--- a/src/Metalama/tests/docker/win-x64/Issue1699X86Sdk/README.md
+++ b/src/Metalama/tests/docker/win-x64/Issue1699X86Sdk/README.md
@@ -1,0 +1,47 @@
+# Regression test for Metalama.Compiler issue #1699
+
+Reproduces
+[metalama/Metalama#1699](https://github.com/metalama/Metalama/issues/1699):
+
+> The task factory "RoslynCodeTaskFactory" could not be loaded from the assembly
+> `C:\Program Files %28x86%29\...\Microsoft.Build.Tasks.Core.dll` (MSB4175)
+
+## Root cause
+
+`Metalama.Compiler.targets` (added in #180) declares a `RoslynCodeTaskFactory`
+`UsingTask` whose `AssemblyFile` is computed with an MSBuild **property function**:
+
+```xml
+AssemblyFile="$([System.IO.Path]::Combine('$(MSBuildToolsPath)', 'Microsoft.Build.Tasks.Core.dll'))"
+```
+
+Property functions escape the MSBuild-special characters `(` and `)` in their
+result to `%28`/`%29`, and a `TaskFactory`'s `AssemblyFile` is consumed **without**
+unescaping. So when `$(MSBuildToolsPath)` contains parentheses the literal
+`Program Files %28x86%29` reaches assembly loading and the build fails.
+
+It only bites when the tools path has parentheses — i.e. full-framework MSBuild
+or an **x86 .NET SDK** under `C:\Program Files (x86)\...`. `dotnet build` on an
+x64 SDK (what the CI matrix uses) never has parentheses, which is why this was
+not caught before. The customer hit it via `VSBuild@1` (VS Build Tools 2026).
+
+## What this scenario does
+
+Installs the **x86** .NET SDK into `C:\Program Files (x86)\dotnet` so a plain
+`dotnet build` sees a paren-containing `$(MSBuildToolsPath)`, then builds a
+trivial class library that references the locally-built `Metalama.Compiler`
+package. `test.ps1` first asserts the precondition (`MSBuildToolsPath` really
+contains `(x86)`), then fails on `MSB4175` or any `%28`/`%29` in the build log.
+
+Red against the buggy targets; green once `AssemblyFile` is wrapped in
+`$([MSBuild]::Unescape(...))`.
+
+## Run
+
+Build the local packages first, then run just this scenario:
+
+```powershell
+# from the repo root
+.\Build.ps1 build -c Debug
+.\src\Metalama\tests\docker\DockerTests.ps1 -Platform win-x64 -Scenario Issue1699X86Sdk
+```

--- a/src/Metalama/tests/docker/win-x64/Issue1699X86Sdk/src/Class1.cs
+++ b/src/Metalama/tests/docker/win-x64/Issue1699X86Sdk/src/Class1.cs
@@ -1,0 +1,8 @@
+namespace Issue1699;
+
+// Trivial type; the point of this scenario is that the project compiles at all
+// under an x86 SDK whose $(MSBuildToolsPath) contains parentheses.
+public class Class1
+{
+    public int Answer => 42;
+}

--- a/src/Metalama/tests/docker/win-x64/Issue1699X86Sdk/src/Directory.Build.props
+++ b/src/Metalama/tests/docker/win-x64/Issue1699X86Sdk/src/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <!-- Isolated from the rest of the Metalama.Compiler repo. -->
+  <PropertyGroup>
+    <!-- DockerTests.ps1 substitutes this placeholder with the locally-built
+         Metalama.Compiler nupkg version found in C:/local-feed. -->
+    <MetalamaCompilerVersion>$LOCAL_COMPILER_VERSION$</MetalamaCompilerVersion>
+  </PropertyGroup>
+</Project>

--- a/src/Metalama/tests/docker/win-x64/Issue1699X86Sdk/src/Directory.Build.targets
+++ b/src/Metalama/tests/docker/win-x64/Issue1699X86Sdk/src/Directory.Build.targets
@@ -1,0 +1,2 @@
+<Project>
+</Project>

--- a/src/Metalama/tests/docker/win-x64/Issue1699X86Sdk/src/Issue1699.csproj
+++ b/src/Metalama/tests/docker/win-x64/Issue1699X86Sdk/src/Issue1699.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Referencing Metalama.Compiler imports Metalama.Compiler.targets, whose
+         RoslynCodeTaskFactory UsingTask is what issue #1699 fails to load.
+         The MetalamaSetDotnetRootHint target runs BeforeTargets="CoreCompile",
+         so a trivial compile is enough to exercise it. No aspects needed. -->
+    <PackageReference Include="Metalama.Compiler" Version="$(MetalamaCompilerVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/src/Metalama/tests/docker/win-x64/Issue1699X86Sdk/src/NuGet.config
+++ b/src/Metalama/tests/docker/win-x64/Issue1699X86Sdk/src/NuGet.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <!-- DockerTests.ps1 stages the locally-built Metalama.Compiler nupkgs into C:/local-feed -->
+    <add key="local-feed" value="C:/local-feed" />
+  </packageSources>
+</configuration>

--- a/src/Metalama/tests/docker/win-x64/Issue1699X86Sdk/src/global.json
+++ b/src/Metalama/tests/docker/win-x64/Issue1699X86Sdk/src/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.301",
+    "rollForward": "latestPatch"
+  }
+}

--- a/src/Metalama/tests/docker/win-x64/Issue1699X86Sdk/test.ps1
+++ b/src/Metalama/tests/docker/win-x64/Issue1699X86Sdk/test.ps1
@@ -28,8 +28,12 @@ if (Select-String -Path build.log -Pattern 'MSB4175' -Quiet) {
     Write-Host 'FAIL: MSB4175 - RoslynCodeTaskFactory could not be loaded (issue #1699).'
     exit 1
 }
-if (Select-String -Path build.log -Pattern '%28|%29' -Quiet) {
-    Write-Host 'FAIL: build log contains an URL-escaped path (%28/%29) - issue #1699 not fixed.'
+# Only treat %28/%29 as the regression when it appears in the assembly path of the
+# task factory itself (i.e. on a Microsoft.Build.Tasks.Core.dll line) - a bare
+# escaped char elsewhere in the log (e.g. an incidental URL/querystring) is not #1699.
+if (Select-String -Path build.log -Pattern 'Microsoft\.Build\.Tasks\.Core\.dll' |
+        Where-Object { $_.Line -match '%2[89]' }) {
+    Write-Host 'FAIL: task-factory assembly path is URL-escaped (%28/%29) - issue #1699 not fixed.'
     exit 1
 }
 if ($buildRc -ne 0) {

--- a/src/Metalama/tests/docker/win-x64/Issue1699X86Sdk/test.ps1
+++ b/src/Metalama/tests/docker/win-x64/Issue1699X86Sdk/test.ps1
@@ -1,0 +1,40 @@
+$ErrorActionPreference = 'Stop'
+Set-Location C:\app
+
+dotnet --info
+
+# Prove the reproduction precondition: the tools path this SDK reports must
+# contain parentheses, otherwise the scenario would pass vacuously.
+Write-Host '--- MSBuildToolsPath ---'
+'<Project><Target Name="P"><Message Importance="high" Text="MSBuildToolsPath=[$(MSBuildToolsPath)]" /></Target></Project>' |
+    Set-Content -Path probe.proj -Encoding utf8
+$probe = dotnet msbuild probe.proj -nologo -v:m 2>&1 | Out-String
+Write-Host $probe
+if ($probe -notmatch '\(x86\)') {
+    Write-Host "FAIL: MSBuildToolsPath does not contain '(x86)' - scenario would not exercise the bug."
+    exit 1
+}
+
+Write-Host '--- restore ---'
+dotnet restore Issue1699.csproj
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+Write-Host '--- build ---'
+dotnet build Issue1699.csproj --no-restore -c Debug 2>&1 | Tee-Object -FilePath build.log
+$buildRc = $LASTEXITCODE
+
+# The bug surfaces as a task-factory load error with an escaped path.
+if (Select-String -Path build.log -Pattern 'MSB4175' -Quiet) {
+    Write-Host 'FAIL: MSB4175 - RoslynCodeTaskFactory could not be loaded (issue #1699).'
+    exit 1
+}
+if (Select-String -Path build.log -Pattern '%28|%29' -Quiet) {
+    Write-Host 'FAIL: build log contains an URL-escaped path (%28/%29) - issue #1699 not fixed.'
+    exit 1
+}
+if ($buildRc -ne 0) {
+    Write-Host "BUILD FAILED (rc=$buildRc)"
+    exit $buildRc
+}
+
+Write-Host 'OK: win-x64/Issue1699X86Sdk scenario passed'

--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/AnyCpu/build/Metalama.Compiler.targets
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/AnyCpu/build/Metalama.Compiler.targets
@@ -14,9 +14,18 @@
     dotnet root. The redirector reads METALAMA_DOTNET_ROOT to enumerate
     installed SDKs for fall-back analyzer resolution.
   -->
+  <!--
+    Wrap the AssemblyFile path in MSBuild::Unescape: property functions (here
+    Path.Combine) escape the MSBuild-special characters '(' and ')' in their
+    result to '%28'/'%29', and a TaskFactory's AssemblyFile is consumed WITHOUT
+    unescaping. When $(MSBuildToolsPath) contains parentheses — e.g. an x86 .NET
+    SDK or VS Build Tools under 'C:\Program Files (x86)\...' — the literal
+    '%28x86%29' would otherwise reach assembly loading and fail with MSB4175
+    (issue #1699).
+  -->
   <UsingTask TaskName="MetalamaSetEnvironmentVariable"
              TaskFactory="RoslynCodeTaskFactory"
-             AssemblyFile="$([System.IO.Path]::Combine('$(MSBuildToolsPath)', 'Microsoft.Build.Tasks.Core.dll'))">
+             AssemblyFile="$([MSBuild]::Unescape($([System.IO.Path]::Combine('$(MSBuildToolsPath)', 'Microsoft.Build.Tasks.Core.dll'))))">
     <ParameterGroup>
       <Name Required="true" ParameterType="System.String" />
       <Value Required="true" ParameterType="System.String" />


### PR DESCRIPTION
## What

`Metalama.Compiler.targets` declares a `RoslynCodeTaskFactory` `UsingTask`
(`MetalamaSetEnvironmentVariable`, added in #180) whose `AssemblyFile` is computed
with a property function:

```xml
AssemblyFile="$([System.IO.Path]::Combine('$(MSBuildToolsPath)', 'Microsoft.Build.Tasks.Core.dll'))"
```

This PR wraps that expression in `$([MSBuild]::Unescape(...))` and adds a Docker
regression scenario.

## Why

MSBuild property functions escape the MSBuild-special characters `(` and `)` in
their result to `%28`/`%29`, and a `TaskFactory`'s `AssemblyFile` is consumed
**without** unescaping. So when `$(MSBuildToolsPath)` contains parentheses, the
literal `Program Files %28x86%29` reaches assembly loading and the build fails:

```
error MSB4175: The task factory "RoslynCodeTaskFactory" could not be loaded from
the assembly "C:\Program Files %28x86%29\...\Microsoft.Build.Tasks.Core.dll".
```

Reported in metalama/Metalama.Compiler#192. It only bites when the tools path has
parentheses — an **x86 .NET SDK** or **VS Build Tools** under
`C:\Program Files (x86)\...` (the customer hit it via `VSBuild@1`). `dotnet build`
on an x64 SDK has no parentheses, which is why the CI matrix never caught it, and
why the regression first appeared in 2026.0 (the `UsingTask` is new in #180) while
2025.1 was unaffected.

## Regression test

New win-x64 Docker scenario `src/Metalama/tests/docker/win-x64/Issue1699X86Sdk/`,
wired into the existing `DockerTests.ps1` harness. It installs the **x86 SDK** into
`C:\Program Files (x86)\dotnet` so a plain `dotnet build` sees a paren-containing
`$(MSBuildToolsPath)`, builds a trivial project referencing the locally-built
`Metalama.Compiler`, asserts the precondition (`MSBuildToolsPath` really contains
`(x86)`), and fails on `MSB4175` or any `%28`/`%29` in the build log.

Verified locally:

| Targets | Scenario |
| --- | --- |
| Before fix (raw `Path.Combine`) | **FAIL** — `MSB4175` / `Program Files %28x86%29` |
| After fix (`Unescape`) | **PASS** — `MSBuildToolsPath=[C:\Program Files (x86)\dotnet\sdk\10.0.301]`, build succeeded |

## Notes for reviewer

- `buildTransitive/Metalama.Compiler.targets` only imports the `build/` copy, so the one-line fix covers both.
- The scenario requires Docker Desktop in **Windows-containers** mode; it is not in the automatic CI matrix (same as the other `win-x64` Docker scenarios).